### PR TITLE
Change video badge text to be middle aligned

### DIFF
--- a/styles/components.css
+++ b/styles/components.css
@@ -97,6 +97,8 @@
 }
 
 .badgeInner {
+  display: flex;
+  align-items: center;
   border-radius: 8px;
   background-color: var(--ui-kit-color-contrast);
   color: var(--ui-kit-color-contrast-fore);


### PR DESCRIPTION
**CHANGES**

FIx alignment of video badge. This is based on our App review and design feedback. Screenshots below. The style is defined in the SDK.

**FEEDBACK**
<img width="1120" alt="image" src="https://github.com/canva-sdks/canva-apps-sdk-starter-kit/assets/95890155/19e1673f-7975-4d74-829c-9f8f49d14bb0">


**BEFORE**

<img width="323" alt="image" src="https://github.com/canva-sdks/canva-apps-sdk-starter-kit/assets/95890155/0e6be127-964b-4b98-89fb-304d3d05ea77">


**AFTER**

<img width="325" alt="image" src="https://github.com/canva-sdks/canva-apps-sdk-starter-kit/assets/95890155/d6fcdf98-0a59-4d31-a9c5-2eeb90c0fbf3">
