### PR TITLE
RC-v2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,49 @@ This repo contains everything you need to get an app up and running in a matter 
 - Node.js `v18`
 - npm `v9`
 
-**Note:** To make sure you're running the correct version of Node.js, we recommend using a version manager, such as [nvm](https://github.com/nvm-sh/nvm#intro). The .nvmrc file in the root directory of this repo will ensure the correct version is used.
+**Note:** To make sure you're running the correct version of Node.js, we recommend using a version manager, such as [nvm](https://github.com/nvm-sh/nvm#intro). The `.nvmrc` file in the root directory of this repo will ensure the correct version is used.
+
+### Installing or updating nvm
+
+To install or update nvm, you should run the [install script](https://github.com/nvm-sh/nvm#installing-and-updating). This can be done either by downloading and running the script manually or by using the following cURL or Wget command:
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+```
+
+```bash
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+```
+
+**Note:**
+After installing or updating nvm, you need to restart your terminal to apply the changes.
 
 ## Quick start
 
-```bash
-git clone git@github.com:canva-sdks/canva-apps-sdk-starter-kit.git
-cd canva-apps-sdk-starter-kit
-npm install
-```
+1. **Clone this repository:**
+ 
+   ```bash
+   git clone git@github.com:canva-sdks/canva-apps-sdk-starter-kit.git
+   ```
+   
+2. **Navigate to the repository directory**:
+   ```bash
+   cd canva-apps-sdk-starter-kit
+   ```
+
+3. **Switch to the required Node.js version:** 
+This repository includes an `.nvmrc` file in the root directory. If you are using nvm, navigate to the root directory of the project and run the following command to switch to the correct Node.js version:
+   ```bash
+   nvm use
+   ```
+
+4. **Install dependencies:**
+
+   ```bash
+   npm install
+   ```
+
+These steps will ensure that you are using the correct version of Node.js as specified by the project and that all necessary dependencies are installed.
 
 ## Using the boilerplate
 

--- a/examples/image_editing_colorize/app.tsx
+++ b/examples/image_editing_colorize/app.tsx
@@ -1,0 +1,170 @@
+import {
+  Button,
+  Rows,
+  FileInput,
+  Text,
+  FileInputItem,
+  Title,
+} from "@canva/app-ui-kit";
+import { ImageMimeType, upload } from "@canva/asset";
+import { addNativeElement } from "@canva/design";
+import { auth } from "@canva/user";
+import * as React from "react";
+import styles from "styles/components.css";
+
+// COLORIZER_URL is the endpoint URL for the colorization service. The URL below is an example only.
+const COLORIZER_URL =
+  "https://r123456.execute-api.us-east-1.amazonaws.com/invocations";
+
+/**
+ * Represents an image that has been colorized.
+ */
+type ColorizedImage = {
+  /** A unique identifier for the image. */
+  id: string;
+
+  /** The URL where the full-sized colorized image can be accessed. */
+  url: string;
+
+  /** The URL where a thumbnail version of the colorized image can be accessed. */
+  thumbnailUrl: string;
+
+  /** The MIME type of the image. */
+  mimeType: ImageMimeType;
+};
+
+/**
+ * Represents a file that has been provided as input.
+ */
+type InputFile = {
+  /** The name of the input file. */
+  name: string;
+
+  /** The Data URI representing the file's data. */
+  dataUri: string;
+};
+
+/**
+ * Converts a File object to a Base64-encoded string.
+ *
+ * @param file - The File object to be converted.
+ * @returns A promise that resolves to a Base64-encoded string.
+ */
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () =>
+      reject(new Error(`Unable to read file: ${file.name}`));
+
+    reader.readAsDataURL(file);
+  });
+}
+
+export const App = () => {
+  const [file, setFile] = React.useState<InputFile | undefined>();
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [colorizedImageUrl, setColorizedImageUrl] = React.useState<
+    string | undefined
+  >();
+
+  const colorize = async () => {
+    if (!file) {
+      return;
+    }
+    setIsLoading(true);
+
+    const token = await auth.getCanvaUserToken();
+
+    // TODO: Make fetch API call to get colorized image
+    const response = await fetch(COLORIZER_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ dataUri: file.dataUri }),
+    });
+
+    const { id, mimeType, thumbnailUrl, url }: ColorizedImage =
+      await response.json();
+
+    // TODO: Set colorized image URL
+    setColorizedImageUrl(url);
+
+    // TODO: Upload asset to user library
+    const result = await upload({
+      type: "IMAGE",
+      id,
+      mimeType,
+      thumbnailUrl,
+      url,
+    });
+
+    // TODO: Add to design
+    await addNativeElement({
+      type: "IMAGE",
+      ref: result.ref,
+    });
+
+    setIsLoading(false);
+  };
+
+  const onDropAcceptedFiles = async ([file]: File[]) => {
+    // TODO: Encode file to base64 and set file state
+    const dataUri = await fileToBase64(file);
+
+    setFile({
+      dataUri,
+      name: file.name,
+    });
+
+    setColorizedImageUrl(undefined);
+  };
+
+  return (
+    <div className={styles.scrollContainer}>
+      <Rows spacing="2u">
+        <Text>
+          Drop your black and white images to bring them to life using our AI
+          Powered Colorizer.
+        </Text>
+        <FileInput
+          stretchButton
+          accept={["image/png", "image/jpeg", "image/jpg"]}
+          onDropAcceptedFiles={onDropAcceptedFiles}
+          multiple={false}
+        />
+        {file && (
+          <>
+            <FileInputItem
+              label={file.name}
+              onDeleteClick={() => {
+                setFile(undefined);
+                setColorizedImageUrl(undefined);
+              }}
+            />
+            <Title>Original:</Title>
+            <img src={file.dataUri} alt={file.name} />
+          </>
+        )}
+        {colorizedImageUrl && (
+          <>
+            <Title>Colorized:</Title>
+            <img src={colorizedImageUrl} alt={file!.name} />
+          </>
+        )}
+        <Button
+          variant="primary"
+          onClick={colorize}
+          loading={isLoading}
+          disabled={file === undefined}
+          stretch
+        >
+          Colorize
+        </Button>
+      </Rows>
+    </div>
+  );
+};

--- a/examples/image_editing_colorize/index.tsx
+++ b/examples/image_editing_colorize/index.tsx
@@ -1,0 +1,20 @@
+import { AppUiProvider } from '@canva/app-ui-kit';
+import * as React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './app';
+import '@canva/app-ui-kit/styles.css';
+
+const root = createRoot(document.getElementById('root')!);
+function render() {
+  root.render(
+    <AppUiProvider>
+      <App />
+    </AppUiProvider>
+  );
+}
+
+render();
+
+if (module.hot) {
+  module.hot.accept('./app', render);
+}


### PR DESCRIPTION
### 🧰 Added
* Added a new `example` based on the workshop presented by @canva-dan during the event [Canva Extend](https://www.eventbrite.com/e/canva-extend-local-edition-auckland-tickets-732450969567) hosted in Auckland, New Zealand.
  
### 🔧 Changed
* Updated the `README.md` with instructions for installing and using `nvm`. Some users were struggling to start the development server.