### PR TITLE
Added support for TIFF in upload, Update examples, fix preview instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2024-04-02
+
+### 🧰 Added
+- `@canva/asset`
+  - Added support for TIFF in `upload`
+
+### 🔧 Changed
+- Minor fix in [README.md](./README.md) Step 2: Preview the app to reflect the latest instructions.
+- `examples`
+  - Updated the [/examples/design_token](/examples/design_token) example to include more checks against important JWT claims.
+  - Downgraded ExpressJS module used in [/examples/design_token](/examples/design_token) from v5 to v4 to be consistent with other examples.
+
 ## 2024-03-21
 
 ### 🧰 Added

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ The local development server only exposes a JavaScript bundle, so you can't prev
 
 To preview an app:
 
-1. Create an app via the [Developer Portal](https://www.canva.com/developers).
+1. Create an app via the [Developer Portal](https://www.canva.com/developers/apps).
 2. Select **App source > Development URL**.
 3. In the **Development URL** field, enter the URL of the development server.
 4. Click **Preview**. This opens the Canva editor (and the app) in a new tab.
-5. Click **Use**. (This screen only appears when when using an app for the first time.)
+5. Click **Open**. (This screen only appears when using an app for the first time.)
 
 The app will appear in the side panel.
 

--- a/examples/design_token/package.json
+++ b/examples/design_token/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^5.0.0-beta.2",
+    "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.1.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "dependencies": {
         "@canva/app-ui-kit": "^3.4.0",
-        "@canva/asset": "^1.4.0",
+        "@canva/asset": "^1.5.0",
         "@canva/design": "^1.6.0",
         "@canva/error": "^1.1.0",
         "@canva/platform": "^1.0.1",
@@ -127,7 +127,7 @@
       "license": "Please refer to the LICENSE.md file in the root directory",
       "dependencies": {
         "cors": "^2.8.5",
-        "express": "^5.0.0-beta.2",
+        "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0"
       },
@@ -2464,9 +2464,9 @@
       }
     },
     "node_modules/@canva/asset": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@canva/asset/-/asset-1.4.0.tgz",
-      "integrity": "sha512-omnMtbxvQT+EZi7Y4LSN51JES3sD76ggV0XDql7E7HP3pGR0IkvnT5x039NEiSMsKJuwUl7GRMnRr9gc2w5URA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@canva/asset/-/asset-1.5.0.tgz",
+      "integrity": "sha512-szmOhi03sN+6PxbvKHrjnBGG7o8pneuNvNuikMDtIaKW77K/LhplWABbNvFNHqmQESXOEjOhzSQuV6D10oWTzg==",
       "peerDependencies": {
         "@canva/error": "^1.0.0"
       }
@@ -6414,16 +6414,16 @@
       "link": true
     },
     "node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -6463,9 +6463,9 @@
       }
     },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@canva/app-ui-kit": "^3.4.0",
-    "@canva/asset": "^1.4.0",
+    "@canva/asset": "^1.5.0",
     "@canva/design": "^1.6.0",
     "@canva/error": "^1.1.0",
     "@canva/platform": "^1.0.1",


### PR DESCRIPTION
## 2024-04-02

### 🧰 Added
- `@canva/asset`
  - Added support for TIFF in `upload`

### 🔧 Changed
- Minor fix in [README.md](./README.md) Step 2: Preview the app to reflect the latest instructions.
- `examples`
  - Updated the [/examples/design_token](/examples/design_token) example to include more checks against important JWT claims.
  - Downgraded ExpressJS module used in [/examples/design_token](/examples/design_token) from v5 to v4 to be consistent with other examples.