### PR TITLE
@canva/design Release DesignToken to GA and add support for `NativeVideoElement`in `AppElement`s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 yarn-error.log
 dist
 secrets.json
+**/*/db.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2024-04-08
+## 2024-04-10
 
 ### 🧰 Added
 - `@canva/design`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2024-04-08
+
+### 🧰 Added
+- `@canva/design`
+  - Added [design.getDesignToken](https://www.canva.dev/docs/apps/using-design-ids) under `@canva/design` which was previously in beta. See the documentation.
+
+### Updated
+- `examples`
+  - Updated [/examples/design_token](/examples/design_token) to use `@canva/design` instead of `@canva/preview/design`
+- `@canva/design`
+  - NativeVideoElement is now supported in app elements. [See the documentation](https://www.canva.dev/docs/apps/creating-app-elements/)
+
+### 🔧 Fixed
+- `examples`
+  - Fixed some authentication examples using a deprecated parameter instead of the JWT middleware 
+
 ## 2024-04-02
 
 ### 🧰 Added

--- a/examples/authentication/backend/server.ts
+++ b/examples/authentication/backend/server.ts
@@ -194,22 +194,15 @@ async function main() {
         return failureResponse();
       }
 
-      // Get the user's ID from the query parameters
-      const { user } = req.query;
-      if (typeof user !== "string") {
-        console.error(
-          `user field in query parameters: expected 'string' but found '${typeof user}'`
-        );
-        res.status(400).send({});
-        return;
-      }
+      // Get the userId from JWT middleware
+      const { userId } = req.canva;
 
       // Load the database
       const data = await db.read();
 
       // Add the user to the database
-      if (!data.users.includes(user)) {
-        data.users.push(user);
+      if (!data.users.includes(userId)) {
+        data.users.push(userId);
         await db.write(data);
       }
 
@@ -244,14 +237,14 @@ async function main() {
    */
   router.post("/configuration/delete", jwtMiddleware, async (req, res) => {
     // Get the user's ID from the request body
-    const { user } = req.body;
+    const { userId } = req.canva;
 
     // Load the database
     const data = await db.read();
 
     // Remove the user from the database
     await db.write({
-      users: data.users.filter((userId) => userId !== user),
+      users: data.users.filter((user) => user !== userId),
     });
 
     // Confirm that the user was removed

--- a/examples/design_token/app.tsx
+++ b/examples/design_token/app.tsx
@@ -8,9 +8,8 @@ import {
 } from "@canva/app-ui-kit";
 import React, { useEffect, useState } from "react";
 import styles from "styles/components.css";
-import { getDesignToken } from "@canva/preview/design";
 import { auth } from "@canva/user";
-import { getDefaultPageDimensions } from "@canva/design";
+import { getDefaultPageDimensions, getDesignToken } from "@canva/design";
 
 type DesignData = {
   title: string;

--- a/examples/digital_asset_management/backend/server.ts
+++ b/examples/digital_asset_management/backend/server.ts
@@ -221,22 +221,15 @@ async function main() {
         return failureResponse();
       }
 
-      // Get the user's ID from the query parameters
-      const { user } = req.query;
-      if (typeof user !== "string") {
-        console.error(
-          `user field in query parameters: expected 'string' but found '${typeof user}'`
-        );
-        res.status(400).send({});
-        return;
-      }
+      // Get the userId from JWT middleware
+      const { userId } = req.canva;
 
       // Load the database
       const data = await db.read();
 
       // Add the user to the database
-      if (!data.users.includes(user)) {
-        data.users.push(user);
+      if (!data.users.includes(userId)) {
+        data.users.push(userId);
         await db.write(data);
       }
 
@@ -270,15 +263,15 @@ async function main() {
    * Developer Portal. Localhost addresses will not work to test this endpoint.
    */
   router.post("/configuration/delete", jwtMiddleware, async (req, res) => {
-    // Get the user's ID from the request body
-    const { user } = req.body;
+    // Get the userId from JWT middleware
+    const { userId } = req.canva;
 
     // Load the database
     const data = await db.read();
 
     // Remove the user from the database
     await db.write({
-      users: data.users.filter((userId) => userId !== user),
+      users: data.users.filter((user) => user !== userId),
     });
 
     // Confirm that the user was removed

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@canva/app-ui-kit": "^3.4.0",
         "@canva/asset": "^1.5.0",
-        "@canva/design": "^1.6.0",
+        "@canva/design": "^1.7.0",
         "@canva/error": "^1.1.0",
         "@canva/platform": "^1.0.1",
         "@canva/preview": "./sdk/preview",
@@ -2472,9 +2472,9 @@
       }
     },
     "node_modules/@canva/design": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@canva/design/-/design-1.6.0.tgz",
-      "integrity": "sha512-80GXWfkpY/9663mXKYfU4rfP9MNXmGRTPvpknFiXd+GM1aO/4aK86gu73tkooCTnuV8J8co9rV9jqjvNx7XX5A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@canva/design/-/design-1.7.0.tgz",
+      "integrity": "sha512-LpD29/EUCKIYtS5f3mKoNyWfUEgyMPdwhYDNZA8OsPXS28xOOX6reh6KQz+OwS9/CG/tEShTMmMQB+ZZQ/eH9g==",
       "peerDependencies": {
         "@canva/error": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@canva/app-ui-kit": "^3.4.0",
     "@canva/asset": "^1.5.0",
-    "@canva/design": "^1.6.0",
+    "@canva/design": "^1.7.0",
     "@canva/error": "^1.1.0",
     "@canva/platform": "^1.0.1",
     "@canva/preview": "./sdk/preview",


### PR DESCRIPTION
## 2024-04-10

### 🧰 Added
- `@canva/design`
  - Added [design.getDesignToken](https://www.canva.dev/docs/apps/using-design-ids) under `@canva/design` which was previously in beta. See the documentation.

### Updated
- `examples`
  - Updated [/examples/design_token](/examples/design_token) to use `@canva/design` instead of `@canva/preview/design`
- `@canva/design`
  - NativeVideoElement is now supported in app elements. [See the documentation](https://www.canva.dev/docs/apps/creating-app-elements/)

### 🔧 Fixed
- `examples`
  - Fixed some authentication examples using a deprecated parameter instead of the JWT middleware 

