### PR TITLE
Added support for `NativeTableElement`, Updates to app process api and Added `OverlayLoadingIndicator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2024-04-16
+
+### 🧰 Added
+- `@canva/preview`
+  - Added `AppProcessInfo.context` for selected_image_overlay surface, allow apps to get additional context data about the surface where the overlay is opened on.
+  - Added `NativeTableElement` to addNativeElement, allows apps to insert a table to a design. [See the documentation](https://www.canva.dev/docs/apps/creating-tables/).
+  - Added `table_wrapper` utils, which helps to create a table element.
+- `examples`
+  - Added [/examples/native_table_elements](/examples/native_table_elements) to demonstrate usage of Table API.
+  - Added `OverlayLoadingIndicator` React component to [/examples/image_editing_overlay](/examples/image_editing_overlay) to align loading overlay loading experience with native experience.
+
+### 🔧 Changed
+- `@canva/preview`
+  - Update typings to [appProcess](http://canva.dev/docs/apps/api/platform-app-process/) API methods including `setOnDispose`, `registerOnMessage` and `requestClose`.
+
+- Updated `@canva/app-components` version in digital_asset_management example.
+
 ## 2024-04-10
 
 ### 🧰 Added

--- a/examples/digital_asset_management/package.json
+++ b/examples/digital_asset_management/package.json
@@ -4,7 +4,7 @@
   "author": "Canva Pty Ltd.",
   "license": "Please refer to the LICENSE.md file in the root directory",
   "dependencies": {
-    "@canva/app-components": "^1.0.0-beta.10",
+    "@canva/app-components": "^1.0.0-beta.15",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/examples/image_editing_overlay/app.tsx
+++ b/examples/image_editing_overlay/app.tsx
@@ -4,7 +4,6 @@ import { ObjectPanel } from "./object_panel";
 import { Overlay } from "./overlay";
 
 export type LaunchParams = {
-  selectedImageUrl: string;
   brushSize: number;
 };
 
@@ -19,5 +18,5 @@ export const App = () => {
     return <Overlay context={context} />;
   }
 
-  throw new Error(`Invalid surface: ${context.surface}`);
+  throw new Error(`Invalid surface`);
 };

--- a/examples/image_editing_overlay/object_panel.tsx
+++ b/examples/image_editing_overlay/object_panel.tsx
@@ -4,8 +4,8 @@ import styles from "styles/components.css";
 import { appProcess } from "@canva/preview/platform";
 import { useOverlay } from "utils/use_overlay_hook";
 import { useSelection } from "utils/use_selection_hook";
-import { getTemporaryUrl } from "@canva/asset";
 import { LaunchParams } from "./app";
+import type { CloseOpts } from "./overlay";
 
 type UIState = {
   brushSize: number;
@@ -20,24 +20,14 @@ export const ObjectPanel = () => {
     isOpen,
     open,
     close: closeOverlay,
-  } = useOverlay("image_selection");
+  } = useOverlay<"image_selection", CloseOpts>("image_selection");
   const selection = useSelection("image");
   const [state, setState] = React.useState<UIState>(initialState);
 
   const openOverlay = async () => {
-    const draft = await selection.read();
-    if (draft.contents.length !== 1) {
-      return;
-    }
-    const { url } = await getTemporaryUrl({
-      type: "IMAGE",
-      ref: draft.contents[0].ref,
-    });
-
     open({
       launchParameters: {
         brushSize: state.brushSize,
-        selectedImageUrl: url,
       } satisfies LaunchParams,
     });
   };

--- a/examples/image_editing_overlay/overlay_loading_indicator.css
+++ b/examples/image_editing_overlay/overlay_loading_indicator.css
@@ -1,0 +1,11 @@
+.overlayLoadingIndicator {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--ui-kit-color-neutral-fore-low);
+  opacity: 0.6;
+}
+
+.overlayLoadingIndicator svg > path {
+  fill: var(--ui-kit-color-neutral-fore);
+}

--- a/examples/image_editing_overlay/overlay_loading_indicator.tsx
+++ b/examples/image_editing_overlay/overlay_loading_indicator.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { Box, LoadingIndicator } from "@canva/app-ui-kit";
+import styles from "./overlay_loading_indicator.css";
+
+export const OverlayLoadingIndicator = () => (
+  <Box
+    display="flex"
+    width="full"
+    height="full"
+    justifyContent="center"
+    alignItems="center"
+    className={styles.overlayLoadingIndicator}
+  >
+    <LoadingIndicator size="large" />
+  </Box>
+);

--- a/examples/native_table_elements/app.tsx
+++ b/examples/native_table_elements/app.tsx
@@ -1,0 +1,242 @@
+import { addNativeElement } from "@canva/preview/design";
+import React from "react";
+import styles from "styles/components.css";
+import {
+  Alert,
+  Button,
+  ColorSelector,
+  Column,
+  Columns,
+  FormField,
+  NumberInput,
+  PlusIcon,
+  Rows,
+  Text,
+  TextInput,
+  Title,
+} from "@canva/app-ui-kit";
+import { CellState, TableState, useTable } from "./use_table_hook";
+
+const initialState: TableState = {
+  rowCount: 4,
+  columnCount: 5,
+  cells: [
+    {
+      rowPos: 1,
+      columnPos: 1,
+      colSpan: 3,
+      rowSpan: 2,
+      text: "2x3",
+      fillColor: "#deffdb",
+    },
+    {
+      rowPos: 1,
+      columnPos: 4,
+      rowSpan: 2,
+      text: "2x1",
+      fillColor: "#dbf1ff",
+    },
+    { rowPos: 4, columnPos: 1, colSpan: 2, text: "1x2" },
+    { rowPos: 3, columnPos: 5, fillColor: "#ffa000" },
+  ],
+};
+
+const CellElement = ({
+  index,
+  value: state,
+  onChange,
+}: {
+  index: number;
+  value: CellState;
+  onChange: (value: CellState) => void;
+}) => {
+  return (
+    <Rows spacing="1u">
+      <Title size="small">Cell #{index}</Title>
+      <Columns spacing="1u">
+        <Column width="1/2">
+          <FormField
+            label="Row position"
+            value={state.rowPos}
+            control={(props) => (
+              <NumberInput
+                {...props}
+                onChange={(value) => {
+                  onChange({ ...state, rowPos: value });
+                }}
+              />
+            )}
+          />
+        </Column>
+        <Column width="1/2">
+          <FormField
+            label="Column position"
+            value={state.columnPos}
+            control={(props) => (
+              <NumberInput
+                {...props}
+                onChange={(value) => {
+                  onChange({ ...state, columnPos: value });
+                }}
+              />
+            )}
+          />
+        </Column>
+      </Columns>
+      <Columns spacing="1u">
+        <Column width="1/2">
+          <FormField
+            label="rowSpan"
+            value={state.rowSpan}
+            control={(props) => (
+              <NumberInput
+                {...props}
+                onChange={(value) => {
+                  onChange({
+                    ...state,
+                    rowSpan: value,
+                  });
+                }}
+              />
+            )}
+          />
+        </Column>
+        <Column width="1/2">
+          <FormField
+            label="colSpan"
+            value={state.colSpan}
+            control={(props) => (
+              <NumberInput
+                {...props}
+                onChange={(value) => {
+                  onChange({
+                    ...state,
+                    colSpan: value,
+                  });
+                }}
+              />
+            )}
+          />
+        </Column>
+      </Columns>
+      <Columns spacing="1u">
+        <Column width="content">
+          <FormField
+            label="Text content"
+            value={state.text}
+            control={(props) => (
+              <TextInput
+                {...props}
+                onChange={(value) => {
+                  onChange({
+                    ...state,
+                    text: value,
+                  });
+                }}
+              />
+            )}
+          />
+        </Column>
+        <Column width="content">
+          <FormField
+            label="Fill color"
+            control={(props) => (
+              <ColorSelector
+                {...props}
+                color={state.fillColor || "#FFFFFF"}
+                onChange={(value) => {
+                  onChange({
+                    ...state,
+                    fillColor: value === "#FFFFFF" ? undefined : value,
+                  });
+                }}
+              />
+            )}
+          />
+        </Column>
+      </Columns>
+    </Rows>
+  );
+};
+
+export const App = () => {
+  const state = useTable(initialState);
+  const [submissionError, setSubmissionError] = React.useState("");
+
+  const onClick = React.useCallback(async () => {
+    try {
+      await addNativeElement(state.toElement());
+    } catch (e) {
+      if (e instanceof Error) {
+        setSubmissionError(e.message);
+      }
+    }
+  }, [state]);
+
+  const onAddCell = React.useCallback(() => {
+    state.cells = [...(state.cells || []), {}];
+  }, []);
+
+  return (
+    <div className={styles.scrollContainer}>
+      <Rows spacing="3u">
+        <Text>
+          This example demonstrates how apps can add native table elements to a
+          design.
+        </Text>
+        {(state.error || submissionError) && (
+          <Alert tone="critical">{state.error || submissionError}</Alert>
+        )}
+        <Columns spacing="3u">
+          <Column width="1/2">
+            <FormField
+              label="Total rows"
+              value={state.rowCount}
+              control={(props) => (
+                <NumberInput
+                  {...props}
+                  onChange={(value) => {
+                    state.rowCount = value;
+                  }}
+                />
+              )}
+            />
+          </Column>
+          <Column width="1/2">
+            <FormField
+              label="Total columns"
+              value={state.columnCount}
+              control={(props) => (
+                <NumberInput
+                  {...props}
+                  onChange={(value) => {
+                    state.columnCount = value;
+                  }}
+                />
+              )}
+            />
+          </Column>
+        </Columns>
+        <Title size="medium">Cell customizations</Title>
+        {state.cells?.map((value, index) => (
+          <CellElement
+            key={`cell-${index}`}
+            index={index}
+            value={value}
+            onChange={(value) => {
+              const cells = state.cells?.slice() || [];
+              cells[index] = value;
+              state.cells = cells;
+            }}
+          />
+        ))}
+        <Button variant="secondary" onClick={onAddCell} icon={PlusIcon}>
+          New custom cell
+        </Button>
+        <Button variant="primary" onClick={onClick} stretch>
+          Add element
+        </Button>
+      </Rows>
+    </div>
+  );
+};

--- a/examples/native_table_elements/index.tsx
+++ b/examples/native_table_elements/index.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { AppUiProvider } from "@canva/app-ui-kit";
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+import "@canva/app-ui-kit/styles.css";
+
+const root = createRoot(document.getElementById("root")!);
+function render() {
+  root.render(
+    <AppUiProvider>
+      <App />
+    </AppUiProvider>
+  );
+}
+
+render();
+
+if (module.hot) {
+  module.hot.accept("./app", render);
+}

--- a/examples/native_table_elements/use_table_hook.ts
+++ b/examples/native_table_elements/use_table_hook.ts
@@ -1,0 +1,152 @@
+import React from "react";
+import { TableWrapper } from "utils/table_wrapper";
+import { NativeTableElement } from "@canva/preview/design";
+
+/**
+ * The current state of a cell within a table.
+ */
+export type CellState = {
+  /**
+   * The position of the cell in the row, starting from `1`.
+   */
+  rowPos?: number;
+  /**
+   * The position of the cell in the column, starting from `1`.
+   */
+  columnPos?: number;
+  /**
+   * The number of rows that the cell should span.
+   */
+  rowSpan?: number;
+  /**
+   * The number of columns that the cell should span.
+   */
+  colSpan?: number;
+  /**
+   * The text content of the cell.
+   */
+  text?: string;
+  /**
+   * The background color of the cell as a hex code. The hex code be six characters long
+   * and preceded with a `#`. For example, `#ff0099`.
+   */
+  fillColor?: string;
+};
+
+/**
+ * The current state of a table.
+ */
+export type TableState = {
+  /**
+   * The number of rows in the table.
+   */
+  rowCount?: number;
+  /**
+   * The number of columns in the table.
+   */
+  columnCount?: number;
+  /**
+   * By default, a table's cells are empty. You can use this property to define the
+   * content and appearance of cells.
+   */
+  cells?: CellState[];
+  /**
+   * An error message to indicate that the table is in an error state.
+   */
+  error?: string;
+};
+
+/**
+ * A hook that simplifies the creation of a table and the management of a table's state.
+ * @param initialState The initial state of the table, such as the number of rows and columns it has.
+ * @returns The current state of the table and methods for interacting with the table.
+ */
+export const useTable = (
+  initialState: TableState
+): TableState & {
+  /**
+   * Converts the table state into a {@link NativeTableElement}. The result can then
+   * be passed into the `addNativeElement` method.
+   */
+  toElement(): NativeTableElement;
+} => {
+  const [rowCount, setRowCount] = React.useState(initialState.rowCount);
+  const [columnCount, setColumnCount] = React.useState(
+    initialState.columnCount
+  );
+  const [cells, setCells] = React.useState<CellState[]>(
+    initialState.cells || []
+  );
+  const [error, setError] = React.useState<string | undefined>();
+  const [wrapper, setWrapper] = React.useState<TableWrapper>(
+    TableWrapper.create(rowCount || 1, columnCount || 1)
+  );
+
+  const toElement = React.useCallback(() => wrapper.toElement(), [wrapper]);
+
+  React.useEffect(() => {
+    setError(undefined);
+    if (typeof rowCount !== "number" || typeof columnCount !== "number") {
+      return;
+    }
+
+    try {
+      const newWrapper = TableWrapper.create(rowCount, columnCount);
+      setWrapper(newWrapper);
+    } catch (e) {
+      if (e instanceof Error) {
+        setError(e.message);
+      }
+    }
+  }, [rowCount, columnCount]);
+
+  React.useEffect(() => {
+    setError(undefined);
+    try {
+      for (const cell of cells) {
+        if (
+          typeof cell.rowPos === "number" &&
+          typeof cell.columnPos === "number"
+        ) {
+          wrapper.setCellDetails(cell.rowPos, cell.columnPos, {
+            rowSpan: cell.rowSpan,
+            colSpan: cell.colSpan,
+            text: cell.text
+              ? { type: "TEXT", children: [cell.text] }
+              : undefined,
+            fill: cell.fillColor ? { color: cell.fillColor } : undefined,
+          });
+        }
+      }
+    } catch (e) {
+      if (e instanceof Error) {
+        setError(e.message);
+      }
+    }
+  }, [cells, wrapper]);
+
+  return {
+    get rowCount() {
+      return rowCount;
+    },
+    set rowCount(value) {
+      setRowCount(value);
+    },
+    get columnCount() {
+      return columnCount;
+    },
+    set columnCount(value) {
+      setColumnCount(value);
+    },
+    get cells() {
+      return cells;
+    },
+    set cells(value) {
+      setCells(value);
+    },
+    get error() {
+      return error;
+    },
+    toElement,
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,7 +294,7 @@
     "examples/digital_asset_management": {
       "license": "Please refer to the LICENSE.md file in the root directory",
       "dependencies": {
-        "@canva/app-components": "^1.0.0-beta.10",
+        "@canva/app-components": "^1.0.0-beta.15",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -2406,12 +2406,13 @@
       "dev": true
     },
     "node_modules/@canva/app-components": {
-      "version": "1.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@canva/app-components/-/app-components-1.0.0-beta.10.tgz",
-      "integrity": "sha512-ejW9u2XAP8brjvuJIXUHTHL7OkvZ7UmhUO2fh4v3zTno/7h7gfNuLBvxqYq5xBJzO1dwR+uk61OS4+Qgp3tpHw==",
+      "version": "1.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@canva/app-components/-/app-components-1.0.0-beta.15.tgz",
+      "integrity": "sha512-Wt37izWkg7G8Yg5xw2a66u8m22lVF1DnkR+EBBcZusAdYuER1kM/U+XT1tSfING3k2aMDuuiQCI0H7Xg4rDLwQ==",
       "dependencies": {
         "@canva/asset": "^1.2.0",
         "@canva/design": "^1.5.0",
+        "@canva/platform": "^1.0.1",
         "@headlessui/react": "^1.7.17",
         "@radix-ui/react-tabs": "^1.0.4",
         "@tanstack/react-query": "^5.14.2",
@@ -12173,7 +12174,7 @@
     },
     "sdk/experimental": {
       "name": "@canva/experimental",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "extraneous": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "peerDependencies": {
@@ -12182,7 +12183,7 @@
     },
     "sdk/preview": {
       "name": "@canva/preview",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "peerDependencies": {
         "@canva/error": "^1.0.0"

--- a/sdk/preview/design/index.d.ts
+++ b/sdk/preview/design/index.d.ts
@@ -6,6 +6,15 @@
 export declare function addAudioTrack(audioTrack: AudioTrack): Promise<void>;
 
 /**
+ * @beta
+ * Adds a native element to the user's design.
+ * @param element - The element to add to the user's design.
+ */
+export declare function addNativeElement(
+  element: NativeElement | NativeElementWithBox | NativeTableElement
+): Promise<void>;
+
+/**
  * @public
  * Adds a native element to the user's design.
  * @param element - The element to add to the user's design.
@@ -160,6 +169,31 @@ export declare type AudioTrack = {
  */
 export declare type Box = Position & (WidthAndHeight | Width | Height);
 
+/**
+ * @beta
+ * A cell for a NativeTableElement. Cells can have text content and a background color.
+ * A cell can also be sized by setting the colSpan and rowSpan values for how many columns
+ * and rows the cell occupies respectively.
+ */
+export declare type Cell = {
+  /**
+   * The text content of the table cell
+   */
+  text?: NativeTextElement;
+  /**
+   * The background of the table cell
+   */
+  fill?: Pick<Fill, "color">;
+  /**
+   * How many columns this cell occupies
+   */
+  colSpan?: number;
+  /**
+   * How many rows this cell occupies
+   */
+  rowSpan?: number;
+};
+
 declare type CommonImageDragConfig = {
   /**
    * The type of element.
@@ -253,8 +287,8 @@ export declare type DesignSelection = {
 };
 
 /**
- * @beta
- * JWT that contains the Design ID, User ID and App ID.
+ * @public
+ * JWT that contains the Design ID and App ID.
  */
 export declare type DesignToken = {
   token: string;
@@ -567,7 +601,7 @@ export declare function getDefaultPageDimensions(): Promise<
 >;
 
 /**
- * @beta
+ * @public
  * Retrieves a signed JWT that contains the Design ID, App ID and User ID.
  */
 export declare function getDesignToken(): Promise<DesignToken>;
@@ -861,6 +895,23 @@ export declare type NativeSimpleElementWithBox = Exclude<
   NativeElementWithBox,
   NativeGroupElementWithBox
 >;
+
+/**
+ * @beta
+ * An element that renders a table.
+ */
+export declare type NativeTableElement = {
+  /**
+   * The type of element.
+   */
+  type: "TABLE";
+  /**
+   * The rows of the table. Each row contains an array of cells, 1 cell per column in the row.
+   */
+  rows: {
+    cells: Cell[];
+  }[];
+};
 
 /**
  * @public

--- a/sdk/preview/package.json
+++ b/sdk/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canva/preview",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "The Canva Apps SDK preview libraries",
   "author": "Canva Pty Ltd.",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/utils/table_wrapper.ts
+++ b/utils/table_wrapper.ts
@@ -1,0 +1,459 @@
+import { Cell, NativeTableElement } from "@canva/preview/design";
+
+const MAX_CELL_COUNT = 225;
+
+// Additional information in the wrapper that are not available in the native table cell element.
+// Currently, only merged cells, but it can later extend to other custom properties, like border, size,...
+type MetaCell = {
+  // If a cell is merged into another cell, then this field should tell that other cell.
+  mergedInto?: { row: number; column: number };
+};
+
+export class TableWrapper {
+  // A shadow of the cell array, that highlight the relationship between merged cells.
+  private readonly metaCells: MetaCell[][];
+
+  private constructor(
+    private readonly rows: {
+      cells: Cell[];
+    }[]
+  ) {
+    this.validateRowColumn();
+    this.metaCells = Array.from({ length: this.rows.length }, () =>
+      Array.from({ length: this.rows[0].cells.length }, () => ({}))
+    );
+    this.syncMergedCellsFromRows();
+  }
+
+  /**
+   * Creates an empty table wrapper.
+   * @param rowCount - The number of rows to create the table with.
+   * @param columnCount - The number of columns to create the table with.
+   */
+  static create(rowCount: number, columnCount: number) {
+    const rows = Array.from({ length: rowCount }, () => ({
+      cells: Array.from({ length: columnCount }, () => ({} as Cell)),
+    }));
+    return new TableWrapper(rows);
+  }
+
+  /**
+   * Converts a native table element into a table wrapper.
+   * @param element - The native table element to convert into a table wrapper.
+   * @throws TableValidationError if element is not a valid {@link NativeTableElement}.
+   */
+  static fromElement(element: NativeTableElement) {
+    if (element.type !== "TABLE") {
+      throw new TableValidationError(
+        `Cannot convert element of type ${element.type} to a table wrapper.`
+      );
+    }
+    if (!Array.isArray(element.rows)) {
+      throw new TableValidationError(
+        `Invalid table element: expected an array of rows, got ${element.rows}`
+      );
+    }
+    const rows = element.rows.map((row) => ({
+      cells: row.cells.map((cell) => ({
+        ...cell,
+        text: cell.text ? { ...cell.text } : undefined,
+        fill: cell.fill ? { ...cell.fill } : undefined,
+      })),
+    }));
+    return new TableWrapper(rows);
+  }
+
+  /**
+   * Return a native table element that can be passed into the `addNativeElement` method.
+   * @returns A native table element.
+   */
+  toElement(): NativeTableElement {
+    return {
+      type: "TABLE",
+      rows: this.rows,
+    };
+  }
+
+  /**
+   * Adds a row to the table after the specified row.
+   * @param afterRowPos The position of the new row. A value of `0` adds a row before the first row, a
+   * value of `1` adds a row after the first row, etc.
+   * @remarks
+   * If the row above and below the new row both have the same properties, the properties will be
+   * copied to the new row. For example, if there are two rows with the same background color and a
+   * row is inserted between them, the new row will also have the same background color.
+   */
+  addRow(afterRowPos: number) {
+    if (afterRowPos < 0 || afterRowPos > this.rows.length) {
+      throw new TableValidationError(
+        `New row position must be between 0 and ${this.rows.length}.`
+      );
+    }
+
+    this.validateRowColumn(1, 0);
+
+    const newRow = {
+      cells: Array.from(
+        { length: this.rows[0].cells.length },
+        () => ({} as Cell)
+      ),
+    };
+    this.rows.splice(afterRowPos, 0, newRow);
+
+    const newMergeCells: MetaCell[] = Array.from(
+      { length: this.rows[0].cells.length },
+      () => ({})
+    );
+    this.metaCells.splice(afterRowPos, 0, newMergeCells);
+
+    if (0 < afterRowPos && afterRowPos < this.rows.length) {
+      // Insert in between rows
+      for (let i = 0; i < newRow.cells.length; i++) {
+        this.mayCopyStyles({
+          frontRowIdx: afterRowPos - 1,
+          frontColumnIdx: i,
+          currentRowIdx: afterRowPos,
+          currentColumnIdx: i,
+          behindRowIdx: afterRowPos + 1,
+          behindColumnIdx: i,
+        });
+      }
+      this.syncCellSpansFromMetaCells();
+    }
+  }
+
+  /**
+   * Adds a column to the table after the specified column.
+   * @param afterColumnPos The position of the new column. A value of `0` adds a column before the first
+   * column, a value of `1` adds a column after the first column, etc.
+   * @remarks
+   * If the column before and after the new column both have the same properties, the properties will be
+   * copied to the new column. For example, if there are two columns with the same background color and a
+   * column is inserted between them, the new column will also have the same background color.
+   */
+  addColumn(afterColumnPos: number) {
+    if (afterColumnPos < 0 || afterColumnPos > this.rows[0].cells.length) {
+      throw new TableValidationError(
+        `New column position must be between 0 and ${this.rows[0].cells.length}.`
+      );
+    }
+
+    this.validateRowColumn(0, 1);
+
+    const newCell: Cell = {};
+    this.rows.forEach((row) => row.cells.splice(afterColumnPos, 0, newCell));
+
+    const newMergeCell: MetaCell = {};
+    this.metaCells.forEach((row) =>
+      row.splice(afterColumnPos, 0, newMergeCell)
+    );
+
+    if (0 < afterColumnPos && afterColumnPos < this.rows[0].cells.length) {
+      // Insert in between columns
+      for (let i = 0; i < this.rows.length; i++) {
+        this.mayCopyStyles({
+          frontRowIdx: i,
+          frontColumnIdx: afterColumnPos - 1,
+          currentRowIdx: i,
+          currentColumnIdx: afterColumnPos,
+          behindRowIdx: i,
+          behindColumnIdx: afterColumnPos + 1,
+        });
+      }
+      this.syncCellSpansFromMetaCells();
+    }
+  }
+
+  /**
+   * Checks if the specified cell is a *ghost cell*.
+   * @param rowPos The row number of the cell, starting from `1`.
+   * @param columnPos The column number of the cell, starting from `1`.
+   * @remarks
+   * A ghost cell is a cell that can not be interacted as it is hidden by a row or column spanning
+   * cell. For example, imagine a row where the first cell has a `colSpan` of `2`. In this case, the
+   * second cell in the row is hidden and is therefore a ghost cell.
+   */
+  isGhostCell(rowPos: number, columnPos: number): boolean {
+    this.validateCellBoundaries(rowPos, columnPos);
+    const rowIndex = rowPos - 1;
+    const columnIndex = columnPos - 1;
+    const { mergedInto } = this.metaCells[rowIndex][columnIndex];
+    if (!mergedInto) {
+      // Not belongs to any merged cell
+      return false;
+    }
+    // Not a ghost cell if it's merged into itself
+    return mergedInto.row !== rowIndex || mergedInto.column !== columnIndex;
+  }
+
+  /**
+   * Returns information about the specified cell.
+   * @param rowPos The row number of the cell, starting from `1`.
+   * @param columnPos The column number of the cell, starting from `1`.
+   * @throws TableValidationError if the cell is a ghost cell. To learn more, see {@link isGhostCell}.
+   */
+  getCellDetails(rowPos: number, columnPos: number) {
+    if (this.isGhostCell(rowPos, columnPos)) {
+      throw new TableValidationError(
+        `The cell at ${rowPos},${columnPos} is squashed into another cell`
+      );
+    }
+    return this.rows[rowPos - 1].cells[columnPos - 1];
+  }
+
+  /**
+   * Sets the details of the specified cell, including its content and appearance.
+   * @param rowPos The row number of the cell, starting from `1`.
+   * @param columnPos The column number of the cell, starting from `1`.
+   * @param details The new details for the cell.
+   * @throws TableValidationError if the cell is a ghost cell. To learn more, see {@link isGhostCell}.
+   */
+  setCellDetails(rowPos: number, columnPos: number, details: Cell) {
+    const rowSpan = details.rowSpan ?? 1;
+    const colSpan = details.colSpan ?? 1;
+    this.validateCellBoundaries(rowPos, columnPos, rowSpan, colSpan);
+    if (this.isGhostCell(rowPos, columnPos)) {
+      throw new TableValidationError(
+        `The cell at ${rowPos},${columnPos} is squashed into another cell`
+      );
+    }
+
+    const rowIndex = rowPos - 1;
+    const columnIndex = columnPos - 1;
+    const { rowSpan: oldRowSpan, colSpan: oldColSpan } =
+      this.rows[rowIndex].cells[columnIndex];
+    this.rows[rowIndex].cells[columnIndex] = details;
+
+    if (oldRowSpan !== rowSpan || oldColSpan !== colSpan) {
+      this.syncMergedCellsFromRows();
+    }
+  }
+
+  private validateRowColumn(
+    toBeAddedRow: number = 0,
+    toBeAddedColumn: number = 0
+  ) {
+    const rowCount = this.rows.length + toBeAddedRow;
+    const columnCount = this.rows[0].cells.length + toBeAddedColumn;
+    if (rowCount === 0) {
+      throw new TableValidationError("Table must have at least one row.");
+    }
+    if (columnCount === 0) {
+      throw new TableValidationError("Table must have at least one column.");
+    }
+    for (const row of this.rows) {
+      if (row.cells.length + toBeAddedColumn !== columnCount) {
+        throw new TableValidationError(
+          "All rows must have the same number of columns."
+        );
+      }
+    }
+    const cellCount = rowCount * columnCount;
+    if (cellCount > MAX_CELL_COUNT) {
+      throw new TableValidationError(
+        `Table cannot have more than ${MAX_CELL_COUNT} cells. Actual: ${rowCount}x${columnCount} = ${cellCount}`
+      );
+    }
+  }
+
+  /**
+   * Read all cell's colSpans and rowSpans and update the merged cells accordingly.
+   * This is opposite sync of {@link syncCellSpansFromMetaCells}.
+   */
+  private syncMergedCellsFromRows(): void {
+    // First, reset metaCells to unmerged state
+    this.metaCells.forEach((cells) =>
+      cells.forEach((c) => (c.mergedInto = undefined))
+    );
+
+    // Then loop through this.rows to find any merged cells
+    for (let rowIndex = 0; rowIndex < this.rows.length; rowIndex++) {
+      const row = this.rows[rowIndex];
+      for (let columnIndex = 0; columnIndex < row.cells.length; columnIndex++) {
+        const cell = row.cells[columnIndex];
+        const colSpan = cell.colSpan || 1;
+        const rowSpan = cell.rowSpan || 1;
+        if (colSpan !== 1 || rowSpan !== 1) {
+          this.validateCellBoundaries(
+            rowIndex + 1,
+            columnIndex + 1,
+            rowSpan,
+            colSpan
+          );
+          this.setMergedCellsByBoundary(
+            rowIndex,
+            columnIndex,
+            rowIndex + rowSpan - 1,
+            columnIndex + colSpan - 1
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Update mergeCells array in accordance with the span boundary
+   * @param fromRow Top most row index
+   * @param fromColumn Left most column index
+   * @param toRow Bottom most row index
+   * @param toColumn Right most column index
+   */
+  private setMergedCellsByBoundary(
+    fromRow: number,
+    fromColumn: number,
+    toRow: number,
+    toColumn: number
+  ) {
+    for (let row = fromRow; row <= toRow; row++) {
+      for (let column = fromColumn; column <= toColumn; column++) {
+        const metaCell = this.metaCells[row][column];
+
+        if (metaCell.mergedInto) {
+          // This cell may be squashed by another merge cell
+          const { row: originalRow, column: originalColumn } =
+            metaCell.mergedInto;
+          if (originalRow !== fromRow && originalColumn !== fromColumn) {
+            // And the old origin cell is mismatched with the new origin,
+            // this mean the current meta cell is merged into 2 different origin cells,
+            // which is forbidden.
+            throw new TableValidationError(
+              `Expanding the cell at ${fromRow},${fromColumn} collides with another merged cell from ${originalRow},${originalColumn}`
+            );
+          }
+        }
+
+        metaCell.mergedInto = {
+          row: fromRow,
+          column: fromColumn,
+        };
+      }
+    }
+  }
+
+  private mayCopyStyles({
+    frontRowIdx,
+    frontColumnIdx,
+    behindRowIdx,
+    behindColumnIdx,
+    currentRowIdx,
+    currentColumnIdx,
+  }: {
+    frontRowIdx: number;
+    frontColumnIdx: number;
+    behindRowIdx: number;
+    behindColumnIdx: number;
+    currentRowIdx: number;
+    currentColumnIdx: number;
+  }) {
+    // Continue span if both front and behind cells belong to a same merged cell
+    const frontMergedCell =
+      this.metaCells[frontRowIdx][frontColumnIdx].mergedInto;
+    const behindMergedCell =
+      this.metaCells[behindRowIdx][behindColumnIdx].mergedInto;
+    if (
+      frontMergedCell &&
+      frontMergedCell.row === behindMergedCell?.row &&
+      frontMergedCell.column === behindMergedCell?.column
+    ) {
+      this.metaCells[currentRowIdx][currentColumnIdx].mergedInto = {
+        ...frontMergedCell,
+      };
+    }
+
+    // Copy fill if both front and behind cells are the same
+    const frontCell = this.rows[frontRowIdx].cells[frontColumnIdx];
+    const behindCell = this.rows[behindRowIdx].cells[behindColumnIdx];
+    if (frontCell.fill && frontCell.fill.color === behindCell.fill?.color) {
+      this.rows[currentRowIdx].cells[currentColumnIdx].fill = {
+        ...frontCell.fill,
+      };
+    }
+  }
+
+  /**
+   * Loop through meta cells and update rowSpan and colSpan of each cell accordingly.
+   * This is opposite sync of {@link syncMergedCellsFromRows}
+   */
+  private syncCellSpansFromMetaCells() {
+    const groups = new Map<string, { row: number; column: number }[]>();
+    for (let row = 0; row < this.metaCells.length; row++) {
+      for (let column = 0; column < this.metaCells[row].length; column++) {
+        // Reset all rowSpans and colSpans
+        this.rows[row].cells[column].rowSpan = undefined;
+        this.rows[row].cells[column].colSpan = undefined;
+
+        const mergedCell = this.metaCells[row][column];
+        if (!mergedCell.mergedInto) {
+          continue;
+        }
+
+        const { row: actualRow, column: actualColumn } = mergedCell.mergedInto;
+        const key = `${actualRow},${actualColumn}`;
+        if (!groups.has(key)) {
+          groups.set(key, []);
+        }
+        groups.get(key)?.push({ row, column });
+      }
+    }
+
+    groups.forEach((cells, key) => {
+      const { minRow, maxRow, minColumn, maxColumn } = cells.reduce(
+        (prev, { row, column }) => {
+          return {
+            minRow: Math.min(prev.minRow, row),
+            maxRow: Math.max(prev.maxRow, row),
+            minColumn: Math.min(prev.minColumn, column),
+            maxColumn: Math.max(prev.maxColumn, column),
+          };
+        },
+        { minRow: Infinity, maxRow: -1, minColumn: Infinity, maxColumn: -1 }
+      );
+      if (
+        !isFinite(minRow) ||
+        !isFinite(minColumn) ||
+        maxRow < 0 ||
+        maxColumn < 0
+      ) {
+        throw new TableValidationError(`Invalid merged cell started at ${key}`);
+      }
+      this.rows[minRow].cells[minColumn].rowSpan = maxRow - minRow + 1;
+      this.rows[minRow].cells[minColumn].colSpan = maxColumn - minColumn + 1;
+    });
+  }
+
+  private validateCellBoundaries(
+    rowPos: number,
+    columnPos: number,
+    rowSpan: number = 1,
+    columnSpan: number = 1
+  ) {
+    if (rowPos < 1 || rowPos > this.rows.length) {
+      throw new TableValidationError(
+        `Row position must be between 1 and ${this.rows.length} (number of rows).`
+      );
+    }
+    if (columnPos < 1 || columnPos > this.rows[0].cells.length) {
+      throw new TableValidationError(
+        `Column position must be between 1 and ${this.rows[0].cells.length} (number of columns).`
+      );
+    }
+    if (rowSpan < 1) {
+      throw new TableValidationError(`Row span must be greater than 0.`);
+    }
+    if (columnSpan < 1) {
+      throw new TableValidationError(`Column span must be greater than 0.`);
+    }
+    if (rowPos + rowSpan - 1 > this.rows.length) {
+      throw new TableValidationError(
+        `Cannot expand ${rowSpan} rows from the cell at ${rowPos},${columnPos}. Table has ${this.rows.length} rows.`
+      );
+    }
+    if (columnPos + columnSpan - 1 > this.rows[0].cells.length) {
+      throw new TableValidationError(
+        `Cannot expand ${columnSpan} columns from the cell at ${rowPos},${columnPos}. Table has ${this.rows[0].cells.length} columns.`
+      );
+    }
+  }
+}
+
+class TableValidationError extends Error {}

--- a/utils/use_overlay_hook.ts
+++ b/utils/use_overlay_hook.ts
@@ -4,7 +4,7 @@ import {
   OverlayTarget,
   overlay as designOverlay,
 } from "@canva/preview/design";
-import { CloseReason, appProcess } from "@canva/preview/platform";
+import { CloseParams, appProcess } from "@canva/preview/platform";
 import React from "react";
 
 const initialOverlayEvent: OverlayOpenableEvent<OverlayTarget> = {
@@ -20,7 +20,10 @@ const initialOverlayEvent: OverlayOpenableEvent<OverlayTarget> = {
  *  4. close - a function close the currently opened overlay.
  * @param target The overlay target to register for whether we can open an overlay.
  */
-export function useOverlay<T extends OverlayTarget>(
+export function useOverlay<
+  T extends OverlayTarget,
+  C extends CloseParams = CloseParams
+>(
   target: T
 ): {
   canOpen: boolean;
@@ -28,7 +31,7 @@ export function useOverlay<T extends OverlayTarget>(
   open: (opts?: {
     launchParameters?: any;
   }) => Promise<AppProcessId | undefined>;
-  close: (opts: { reason: CloseReason }) => Promise<void>;
+  close: (opts: C) => Promise<void>;
 } {
   const [overlay, setOverlay] =
     React.useState<OverlayOpenableEvent<T>>(initialOverlayEvent);
@@ -60,9 +63,9 @@ export function useOverlay<T extends OverlayTarget>(
     }
   };
 
-  const close = async (opts: { reason: CloseReason }) => {
+  const close = async (opts: C) => {
     if (overlayId) {
-      appProcess.requestClose(overlayId, { reason: opts.reason });
+      appProcess.requestClose<C>(overlayId, opts);
     }
   };
 


### PR DESCRIPTION
### 🧰 Added
- `@canva/preview`
  - Added `AppProcessInfo.context` for selected_image_overlay surface, allow apps to get additional context data about the surface where the overlay is opened on.
  - Added `NativeTableElement` to addNativeElement, allows apps to insert a table to a design. [See the documentation](https://www.canva.dev/docs/apps/creating-tables/).
  - Added `table_wrapper` utils, which helps to create a table element.
- `examples`
  - Added [/examples/native_table_elements](/examples/native_table_elements) to demonstrate usage of Table API.
  - Added `OverlayLoadingIndicator` React component to [/examples/image_editing_overlay](/examples/image_editing_overlay) to align loading overlay loading experience with native experience.

### 🔧 Changed
- `@canva/preview`
  - Update typings to [appProcess](http://canva.dev/docs/apps/api/platform-app-process/) API methods including `setOnDispose`, `registerOnMessage` and `requestClose`.

- Updated `@canva/app-components` version in digital_asset_management example.