### PR TITLE
Overlay and AppProcess API Public Release and updated app examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2024-05-06
+
+### 🧰 Added
+- `@canva/design`
+  - Added [design.overlay.registerOnCanOpen](http://canva.dev/docs/apps/api/design-overlay-register-on-can-open/) which was previously in beta.
+- `@canva/platform`
+  - Added [appProcess](https://www.canva.dev/docs/apps/api/platform-app-process/) under `@canva/platform` which was previously in beta.
+
+### 🔧 Changed
+- `examples`
+  - Remove `dataUrl` usages in all examples. We recommend [Upload API](https://www.canva.dev/docs/apps/api/asset-upload/#uploading-images) before adding images to the design.
+  - Updated [/examples/image_editing_overlay](/examples/image_editing_overlay) to use `@canva/design` and `@canva/platform` instead of `@canva/preview`.
+- `utils/backend`
+  - Fixed a number of minor linting and typing related warnings.
+- `examples/digital_asset_management`
+  - Updated `@canva/app-components` to version `1.0.0-beta.17` in `digital_asset_management` example.
+- `README.md`
+  - Minor ordering changes of content in the repository [README.md](/README.md).
+
 ## 2024-04-23
 
 ### 🧰 Added

--- a/README.md
+++ b/README.md
@@ -78,64 +78,39 @@ To enable HMR:
 7. Restart the local development server.
 8. Reload the app manually to ensure that HMR takes effect.
 
-## Previewing apps in Safari
-
-By default, the development server is not HTTPS-enabled. This is convenient, as there's no need for a security certificate, but it prevents apps from being previewed in Safari.
-
 <details>
-  <summary>Why Safari requires the development server to be HTTPS-enabled</summary>
+  <summary>Previewing apps in Safari</summary>
 
-Canva itself is served via HTTPS and most browsers prevent HTTPS pages from loading scripts via non-HTTPS connections. Chrome and Firefox make exceptions for local servers, such as `localhost`, but Safari does not, so if you're using Safari, the development server must be HTTPS-enabled.
+  By default, the development server is not HTTPS-enabled. This is convenient, as there's no need for a security certificate, but it prevents apps from being previewed in Safari.
 
-To learn more, see [Loading mixed-content resources](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content#loading_mixed-content_resources).
+  **Why Safari requires the development server to be HTTPS-enabled?**
 
+  Canva itself is served via HTTPS and most browsers prevent HTTPS pages from loading scripts via non-HTTPS connections. Chrome and Firefox make exceptions for local servers, such as `localhost`, but Safari does not, so if you're using Safari, the development server must be HTTPS-enabled.
+
+  To learn more, see [Loading mixed-content resources](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content#loading_mixed-content_resources).
+
+  To preview apps in Safari:
+
+  1. Start the development server with HTTPS enabled:
+
+  ```bash
+  # Run the main app
+  npm start --use-https
+
+  # Run an example
+  npm start <example-name> --use-https
+  ```
+
+  2. Navigate to <https://localhost:8080>.
+  3. Bypass the invalid security certificate warning:
+    1. Click **Show details**.
+    2. Click **Visit website**.
+  4. In the Developer Portal, set the app's **Development URL** to <https://localhost:8080>.
+
+  You need to bypass the invalid security certificate warning every time you start the local server. A similar warning will appear in other browsers (and will need to be bypassed) whenever HTTPS is enabled.
 </details>
 
-To preview apps in Safari:
-
-1. Start the development server with HTTPS enabled:
-
-   ```bash
-   # Run the main app
-   npm start --use-https
-
-   # Run an example
-   npm start <example-name> --use-https
-   ```
-
-2. Navigate to <https://localhost:8080>.
-3. Bypass the invalid security certificate warning:
-   1. Click **Show details**.
-   2. Click **Visit website**.
-4. In the Developer Portal, set the app's **Development URL** to <https://localhost:8080>.
-
-You need to bypass the invalid security certificate warning every time you start the local server. A similar warning will appear in other browsers (and will need to be bypassed) whenever HTTPS is enabled.
-
-## Running the examples
-
-The `examples` directory contains example apps that demonstrate the available APIs.
-
-To explore all of our different examples, run the following command:
-
-```bash
-npm start examples
-```
-
-Alternatively, you can run a particular example directly via the following command:
-
-```bash
-npm start <example-name>
-```
-
-But replace `<example-name>` with the name of an example, like so:
-
-```bash
-npm start native_image_elements
-```
-
-Like the boilerplate, a development server becomes available at <http://localhost:8080>.
-
-### Running an example's backend
+## Running an example's backend
 
 Some examples have a backend. This backend is defined in the example's `backend/server.ts` file, automatically starts when the `npm start` command is run, and becomes available at <http://localhost:3001>.
 

--- a/examples/digital_asset_management/package.json
+++ b/examples/digital_asset_management/package.json
@@ -4,7 +4,7 @@
   "author": "Canva Pty Ltd.",
   "license": "Please refer to the LICENSE.md file in the root directory",
   "dependencies": {
-    "@canva/app-components": "^1.0.0-beta.15",
+    "@canva/app-components": "^1.0.0-beta.17",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/examples/drag_and_drop_audio/app.tsx
+++ b/examples/drag_and_drop_audio/app.tsx
@@ -8,9 +8,6 @@ const AUDIO_DURATION_MS = 86_047;
 
 const uploadAudio = () => {
   return upload({
-    // An alphanumeric string that is unique for each asset. If given the same
-    // id, the existing asset for that id will be used instead.
-    id: "uniqueAudioIdentifier",
     title: "MP3 Audio Track",
     durationMs: AUDIO_DURATION_MS,
     mimeType: "audio/mp3",

--- a/examples/drag_and_drop_image/app.tsx
+++ b/examples/drag_and_drop_image/app.tsx
@@ -7,9 +7,6 @@ import styles from "styles/components.css";
 
 const uploadExternalImage = () => {
   return upload({
-    // An alphanumeric string that is unique for each asset. If given the same
-    // id, the existing asset for that id will be used instead.
-    id: "uniqueExternalImageIdentifier",
     mimeType: "image/jpeg",
     thumbnailUrl:
       "https://www.canva.dev/example-assets/image-import/grass-image-thumbnail.jpg",
@@ -22,9 +19,6 @@ const uploadExternalImage = () => {
 
 const uploadLocalImage = () => {
   return upload({
-    // An alphanumeric string that is unique for each asset. If given the same
-    // id, the existing asset for that id will be used instead.
-    id: "uniqueLocalImageIdentifier",
     mimeType: "image/jpeg",
     thumbnailUrl: dog,
     type: "IMAGE",
@@ -34,13 +28,14 @@ const uploadLocalImage = () => {
   });
 };
 
-const insertLocalImage = () => {
-  addNativeElement({ type: "IMAGE", dataUrl: dog });
+const insertLocalImage = async () => {
+  const { ref } = await uploadLocalImage();
+  await addNativeElement({ type: "IMAGE", ref });
 };
 
 const insertExternalImage = async () => {
   const { ref } = await uploadExternalImage();
-  addNativeElement({ type: "IMAGE", ref });
+  await addNativeElement({ type: "IMAGE", ref });
 };
 
 export const App = () => {

--- a/examples/drag_and_drop_video/app.tsx
+++ b/examples/drag_and_drop_video/app.tsx
@@ -6,9 +6,6 @@ import styles from "styles/components.css";
 
 const uploadVideo = () => {
   return upload({
-    // An alphanumeric string that is unique for each asset. If given the same
-    // id, the existing asset for that id will be used instead.
-    id: "uniqueBeachVideoIdentifier",
     mimeType: "video/mp4",
     thumbnailImageUrl:
       "https://www.canva.dev/example-assets/video-import/beach-thumbnail-image.jpg",

--- a/examples/image_editing_overlay/app.tsx
+++ b/examples/image_editing_overlay/app.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { appProcess } from "@canva/preview/platform";
+import { appProcess } from "@canva/platform";
 import { ObjectPanel } from "./object_panel";
 import { Overlay } from "./overlay";
 

--- a/examples/image_editing_overlay/object_panel.tsx
+++ b/examples/image_editing_overlay/object_panel.tsx
@@ -1,7 +1,7 @@
 import { Rows, FormField, Button, Slider } from "@canva/app-ui-kit";
 import * as React from "react";
 import styles from "styles/components.css";
-import { appProcess } from "@canva/preview/platform";
+import { appProcess } from "@canva/platform";
 import { useOverlay } from "utils/use_overlay_hook";
 import { LaunchParams } from "./app";
 import type { CloseOpts } from "./overlay";

--- a/examples/image_editing_overlay/overlay.tsx
+++ b/examples/image_editing_overlay/overlay.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
-import { AppProcessInfo, CloseParams } from "sdk/preview/platform";
 import { LaunchParams } from "./app";
 import { getTemporaryUrl, upload } from "@canva/asset";
 import { useSelection } from "utils/use_selection_hook";
-import { appProcess } from "@canva/preview/platform";
+import { appProcess, AppProcessInfo, CloseParams } from "@canva/platform";
 import { SelectionEvent } from "@canva/design";
 
 // App can extend CloseParams type to send extra data when closing the overlay
@@ -116,7 +115,7 @@ export const Overlay = (props: OverlayProps) => {
     return void appProcess.current.setOnDispose<CloseOpts>(
       async ({ reason }) => {
         // abort if image has not loaded or receive `aborted` signal
-        if (reason === "aborted" || !img.complete) {
+        if (reason === "aborted" || !img.src || !img.complete) {
           return;
         }
         const dataUrl = canvas.toDataURL();

--- a/examples/page_addition/app.tsx
+++ b/examples/page_addition/app.tsx
@@ -9,6 +9,7 @@ import { CanvaError } from "@canva/error";
 import weather from "assets/images/weather.png";
 import React from "react";
 import styles from "styles/components.css";
+import { upload } from "@canva/asset";
 
 const IMAGE_ELEMENT_WIDTH = 50;
 const IMAGE_ELEMENT_HEIGHT = 50;
@@ -16,25 +17,35 @@ const TEXT_ELEMENT_WIDTH = 130;
 const HEADER_ELEMENT_SCALE_FACTOR = 0.2;
 const EMBED_ELEMENT_SCALE_FACTOR = 0.4;
 
-const headerElement: NativeGroupElement = {
-  type: "GROUP",
-  children: [
-    {
-      type: "IMAGE",
-      dataUrl: weather,
-      top: 0,
-      left: 0,
-      width: IMAGE_ELEMENT_WIDTH,
-      height: IMAGE_ELEMENT_HEIGHT,
-    },
-    {
-      type: "TEXT",
-      children: ["Weather Forecast"],
-      top: IMAGE_ELEMENT_HEIGHT,
-      left: IMAGE_ELEMENT_WIDTH / 2 - TEXT_ELEMENT_WIDTH / 2,
-      width: TEXT_ELEMENT_WIDTH,
-    },
-  ],
+const createHeaderElement = async (): Promise<NativeGroupElement> => {
+  const { ref } = await upload({
+    mimeType: "image/png",
+    thumbnailUrl: weather,
+    type: "IMAGE",
+    url: weather,
+    width: 100,
+    height: 100,
+  });
+  return {
+    type: "GROUP",
+    children: [
+      {
+        type: "IMAGE",
+        ref,
+        top: 0,
+        left: 0,
+        width: IMAGE_ELEMENT_WIDTH,
+        height: IMAGE_ELEMENT_HEIGHT,
+      },
+      {
+        type: "TEXT",
+        children: ["Weather Forecast"],
+        top: IMAGE_ELEMENT_HEIGHT,
+        left: IMAGE_ELEMENT_WIDTH / 2 - TEXT_ELEMENT_WIDTH / 2,
+        width: TEXT_ELEMENT_WIDTH,
+      },
+    ],
+  };
 };
 
 const embedElement: NativeEmbedElement = {
@@ -73,6 +84,7 @@ export const App = () => {
         defaultPageDimensions.width * HEADER_ELEMENT_SCALE_FACTOR;
       const embedElementWidth =
         defaultPageDimensions.width * EMBED_ELEMENT_SCALE_FACTOR;
+      const headerElement = await createHeaderElement();
       await addPage({
         title: "Weather forecast",
         elements: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
       "dependencies": {
         "@canva/app-ui-kit": "^3.4.0",
         "@canva/asset": "^1.5.0",
-        "@canva/design": "^1.7.0",
+        "@canva/design": "^1.8.0",
         "@canva/error": "^1.1.0",
-        "@canva/platform": "^1.0.1",
+        "@canva/platform": "^1.1.0",
         "@canva/preview": "./sdk/preview",
         "@canva/user": "^1.0.0",
         "react": "^18.1.0",
@@ -297,7 +297,7 @@
     "examples/digital_asset_management": {
       "license": "Please refer to the LICENSE.md file in the root directory",
       "dependencies": {
-        "@canva/app-components": "^1.0.0-beta.15",
+        "@canva/app-components": "^1.0.0-beta.17",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -2409,9 +2409,9 @@
       "dev": true
     },
     "node_modules/@canva/app-components": {
-      "version": "1.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@canva/app-components/-/app-components-1.0.0-beta.15.tgz",
-      "integrity": "sha512-Wt37izWkg7G8Yg5xw2a66u8m22lVF1DnkR+EBBcZusAdYuER1kM/U+XT1tSfING3k2aMDuuiQCI0H7Xg4rDLwQ==",
+      "version": "1.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@canva/app-components/-/app-components-1.0.0-beta.17.tgz",
+      "integrity": "sha512-/CkdKdKHJJCZ5vcZDmrG/yBUk5uxgAA+WvUxT36/iWZbd0QJVKEgX052YOR5wnIExgySREcE10CK5GyEx/icnA==",
       "dependencies": {
         "@canva/asset": "^1.2.0",
         "@canva/design": "^1.5.0",
@@ -2426,7 +2426,7 @@
         "react-router-dom": "^6.20.1"
       },
       "peerDependencies": {
-        "@canva/app-ui-kit": "^3.2.0",
+        "@canva/app-ui-kit": "^3.4.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
       }
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@canva/design": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@canva/design/-/design-1.7.0.tgz",
-      "integrity": "sha512-LpD29/EUCKIYtS5f3mKoNyWfUEgyMPdwhYDNZA8OsPXS28xOOX6reh6KQz+OwS9/CG/tEShTMmMQB+ZZQ/eH9g==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@canva/design/-/design-1.8.0.tgz",
+      "integrity": "sha512-n4cQ5x5z+SZu506JMszv8S/XoQMIkc/giE1bLTYWQN1fMgDCyAVYSpFuZd5uulzU9gYbBmTAmfsYdaKjLT0IWg==",
       "peerDependencies": {
         "@canva/error": "^1.0.0"
       }
@@ -2489,9 +2489,9 @@
       "integrity": "sha512-CvSDflv0UX2C2lzSoEsR13HnospTUugAyX9PAuKbsoMDMHPzGDotT/y6xu3YGCGvKogMBkxbVnW+g9vEPjMC3Q=="
     },
     "node_modules/@canva/platform": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@canva/platform/-/platform-1.0.1.tgz",
-      "integrity": "sha512-HdBYk905LocK/Yndkf0cS47W9CIZNLux/O4IMgkSnA//veChSCbCbCEiCzcrmmO5U1p++jcp+hjiULWIRktVCA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@canva/platform/-/platform-1.1.0.tgz",
+      "integrity": "sha512-IqPZ4OJb3So2bF+0RP3mAdDzzfGdNDbvajrkkBSWX+O29QEBVbi0EeixJemSvp2mQtrg5Y3e67KuUvCwefAxcw==",
       "peerDependencies": {
         "@canva/error": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "dependencies": {
     "@canva/app-ui-kit": "^3.4.0",
     "@canva/asset": "^1.5.0",
-    "@canva/design": "^1.7.0",
+    "@canva/design": "^1.8.0",
     "@canva/error": "^1.1.0",
-    "@canva/platform": "^1.0.1",
+    "@canva/platform": "^1.1.0",
     "@canva/preview": "./sdk/preview",
     "@canva/user": "^1.0.0",
     "react": "^18.1.0",

--- a/sdk/preview/design/index.d.ts
+++ b/sdk/preview/design/index.d.ts
@@ -109,7 +109,7 @@ export declare type AppElementRenderer<A extends AppElementData> = (
 export declare type AppElementRendererOutput = NativeSimpleElementWithBox[];
 
 /**
- * @beta
+ * @public
  * A unique identifier that references an app runtime process
  */
 export declare type AppProcessId = string & {
@@ -248,7 +248,8 @@ export declare type Coordinates = {
 };
 
 /**
- * @beta
+ * @public
+ * Provides methods for interacting with design overlay
  */
 export declare type DesignOverlay = {
   /**
@@ -1014,17 +1015,18 @@ export declare type NativeVideoElementWithBox = NativeVideoElement & Box;
 declare type ObjectPrimitive = Boolean | String;
 
 /**
- * @beta
+ * @public
  * An alias for the DesignOverlay interface, providing access to design overlay related functionality
  */
 export declare const overlay: DesignOverlay;
 
 /**
- * @beta
+ * @public
+ * Information about whether the overlay can be opened or not on a particular {@link OverlayTarget}
  */
 export declare type OverlayOpenableEvent<Target extends OverlayTarget> = {
   /**
-   * An event indicating whether the overlay can be opened or not when {@link OverlayTarget} is `"image_selection"`.
+   * An event indicating whether the overlay can be opened or not when {@link OverlayTarget} is `"image_selection"`
    */
   ["image_selection"]:
     | OverlayUnopenableEvent
@@ -1043,12 +1045,14 @@ export declare type OverlayOpenableEvent<Target extends OverlayTarget> = {
 }[Target];
 
 /**
- * @beta
+ * @public
+ * The target to check if an overlay can be opened for
  */
 export declare type OverlayTarget = "image_selection";
 
 /**
- * @beta
+ * @public
+ * Information about the overlay when it can not be opened on a particular {@link OverlayTarget}
  */
 declare type OverlayUnopenableEvent = {
   canOpen: false;

--- a/sdk/preview/platform/index.d.ts
+++ b/sdk/preview/platform/index.d.ts
@@ -1,11 +1,11 @@
 /**
- * @beta
+ * @public
  * An API for interacting with the App Process.
  */
 export declare interface AppProcess {
   readonly current: CurrentAppProcess;
   /**
-   * @beta
+   * @public
    * Request the termination of an app process.
    * @param target - The id of the app process to close.
    * @param params - A parameters object passed to all callback functions registered via registerOnBeforeClose API for the provided AppProcessId.
@@ -25,7 +25,7 @@ export declare interface AppProcess {
     params: T
   ): Promise<void>;
   /**
-   * @beta
+   * @public
    * Registers a callback to be executed when the state of the specified app process changes.
    * @param target - The id of the app process for which to register the callback.
    * @param callback - Callback function triggered on state change
@@ -58,12 +58,12 @@ export declare interface AppProcess {
 
 /**
  * An alias for the AppProcess interface for interacting with the App Process.
- * @beta
+ * @public
  */
 export declare const appProcess: AppProcess;
 
 /**
- * @beta
+ * @public
  * The unique identifier for an app process.
  */
 export declare type AppProcessId = string & {
@@ -71,7 +71,7 @@ export declare type AppProcessId = string & {
 };
 
 /**
- * @beta
+ * @public
  * Information about an app process.
  */
 export declare type AppProcessInfo<T> = {
@@ -90,7 +90,7 @@ export declare type AppProcessInfo<T> = {
 };
 
 /**
- * @beta
+ * @public
  * The types of surfaces that can run an app process.
  */
 export declare type AppSurface =
@@ -104,7 +104,7 @@ export declare type AppSurface =
   | "selected_image_overlay";
 
 /**
- * @beta
+ * @public
  * The parameters specified when closing an app process.
  * @remarks
  * CloseParams are passed on to the callback function registered for handling the termination of an app process,
@@ -116,7 +116,7 @@ export declare type CloseParams = {
 };
 
 /**
- * @beta
+ * @public
  * The reasons why an app process is closed.
  */
 export declare type CloseReason =
@@ -132,17 +132,17 @@ export declare type CloseReason =
   | "aborted";
 
 /**
- * @beta
+ * @public
  * Represents and exposes functionality specific to the currently running app process.
  */
 export declare type CurrentAppProcess = {
   /**
-   * @beta
+   * @public
    * Retrieves information about the current app process.
    */
   getInfo<T extends any>(): AppProcessInfo<T>;
   /**
-   * @beta
+   * @public
    * Requests the current app process be closed.
    * @param params - A parameters object passed to all callback functions registered via registerOnBeforeClose API for the current process.
    * In addition to the required 'reason' field, app can choose to pass any structured data via params.
@@ -157,7 +157,7 @@ export declare type CurrentAppProcess = {
    */
   requestClose<T extends CloseParams>(params: T): Promise<void>;
   /**
-   * @beta
+   * @public
    * Registers a callback to be executed when the current app process is about to close.
    * @remarks Only allow registering one callback.
    * Subsequential invokes of the API will override the existing callback.
@@ -178,7 +178,7 @@ export declare type CurrentAppProcess = {
 export declare function getPlatformInfo(): PlatformInfo;
 
 /**
- * @beta
+ * @public
  * The type of a callback that is invoked when an app process is being closed.
  * @returns a promise.
  */
@@ -255,7 +255,7 @@ export declare type PlatformInfo = {
 };
 
 /**
- * @beta
+ * @public
  * The states are an app process.
  */
 export declare type ProcessState =

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
       "es2020.promise",
       "es2020.string"
     ],
-    "types": ["node"],
+    "types": ["node", "jest"],
     "composite": true,
     "declaration": true,
     "declarationMap": true,

--- a/utils/backend/base_backend/create.ts
+++ b/utils/backend/base_backend/create.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import * as express from "express";
 import * as http from "http";
 import * as https from "https";

--- a/utils/backend/jwt_middleware/jwt_middleware.ts
+++ b/utils/backend/jwt_middleware/jwt_middleware.ts
@@ -1,7 +1,11 @@
+/* eslint-disable no-console */
+import * as chalk from "chalk";
 import * as debug from "debug";
-import { Request, Response, NextFunction } from "express";
+import type { Request, Response, NextFunction } from "express";
 import * as jwt from "jsonwebtoken";
 import { JwksClient, SigningKeyNotFoundError } from "jwks-rsa";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import Express from "express-serve-static-core";
 
 /**
  * Prefix your start command with `DEBUG=express:middleware:jwt` to enable debug logging
@@ -58,7 +62,7 @@ const createJwksUrl = (appId: string) =>
  */
 export function createJwtMiddleware(
   appId: string,
-  getTokenFromRequest: getTokenFromRequest = getTokenFromHttpHeader
+  getTokenFromRequest: GetTokenFromRequest = getTokenFromHttpHeader
 ): (req: Request, res: Response, next: NextFunction) => void {
   const jwksClient = new JwksClient({
     cache: true,
@@ -119,7 +123,12 @@ export function createJwtMiddleware(
       }
 
       if (e instanceof SigningKeyNotFoundError) {
-        return sendUnauthorizedResponse(res, "Public key not found");
+        return sendUnauthorizedResponse(
+          res,
+          `Public key not found. ${chalk.bgRedBright(
+            "Ensure you have the correct App_ID set"
+          )}.`
+        );
       }
 
       if (e instanceof jwt.JsonWebTokenError) {
@@ -135,9 +144,9 @@ export function createJwtMiddleware(
   };
 }
 
-export type getTokenFromRequest = (req: Request) => Promise<string> | string;
+export type GetTokenFromRequest = (req: Request) => Promise<string> | string;
 
-export const getTokenFromQueryString: getTokenFromRequest = (
+export const getTokenFromQueryString: GetTokenFromRequest = (
   req: Request
 ): string => {
   // The name of a query string parameter bearing the JWT
@@ -165,7 +174,7 @@ export const getTokenFromQueryString: getTokenFromRequest = (
   return queryParam;
 };
 
-export const getTokenFromHttpHeader: getTokenFromRequest = (
+export const getTokenFromHttpHeader: GetTokenFromRequest = (
   req: Request
 ): string => {
   // The names of a HTTP header bearing the JWT, and a scheme

--- a/utils/backend/jwt_middleware/tests/jwt_middleware.tests.ts
+++ b/utils/backend/jwt_middleware/tests/jwt_middleware.tests.ts
@@ -1,9 +1,10 @@
-import { NextFunction, Request, Response } from "express";
-import { DecodeOptions, Jwt, Secret, VerifyOptions } from "jsonwebtoken";
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+import type { NextFunction, Request, Response } from "express";
+import type { DecodeOptions, Jwt, Secret, VerifyOptions } from "jsonwebtoken";
 import type { JwksClient, SigningKey } from "jwks-rsa";
 import type {
   createJwtMiddleware,
-  getTokenFromRequest,
+  GetTokenFromRequest,
 } from "../jwt_middleware";
 
 type Middleware = (req: Request, res: Response, next: NextFunction) => void;
@@ -18,7 +19,7 @@ describe("createJwtMiddleware", () => {
   class FakeJsonWebTokenError extends Error {}
   class FakeTokenExpiredError extends Error {}
 
-  let fakeGetTokenFromRequest: jest.MockedFn<getTokenFromRequest>;
+  let fakeGetTokenFromRequest: jest.MockedFn<GetTokenFromRequest>;
   let verify: jest.MockedFn<
     (
       token: string,
@@ -102,7 +103,7 @@ describe("createJwtMiddleware", () => {
   describe("When called", () => {
     beforeEach(() => {
       req = {
-        header: (name: string) => undefined,
+        header: (_name: string) => undefined,
       } as Request;
 
       res = {

--- a/utils/use_overlay_hook.ts
+++ b/utils/use_overlay_hook.ts
@@ -3,8 +3,8 @@ import {
   OverlayOpenableEvent,
   OverlayTarget,
   overlay as designOverlay,
-} from "@canva/preview/design";
-import { CloseParams, appProcess } from "@canva/preview/platform";
+} from "@canva/design";
+import { CloseParams, appProcess } from "@canva/platform";
 import React from "react";
 
 const initialOverlayEvent: OverlayOpenableEvent<OverlayTarget> = {


### PR DESCRIPTION
## 2024-05-06

### 🧰 Added
- `@canva/design`
  - Added [design.overlay.registerOnCanOpen](http://canva.dev/docs/apps/api/design-overlay-register-on-can-open/) which was previously in beta.
- `@canva/platform`
  - Added [appProcess](https://www.canva.dev/docs/apps/api/platform-app-process/) under `@canva/platform` which was previously in beta.

### 🔧 Changed
- `examples`
  - Remove `dataUrl` usages in all examples. We recommend [Upload API](https://www.canva.dev/docs/apps/api/asset-upload/#uploading-images) before adding images to the design.
  - Updated [/examples/image_editing_overlay](/examples/image_editing_overlay) to use `@canva/design` and `@canva/platform` instead of `@canva/preview`.
- `utils/backend`
  - Fixed a number of minor linting and typing related warnings.
- `examples/digital_asset_management`
  - Updated `@canva/app-components` to version `1.0.0-beta.17` in `digital_asset_management` example.
- `README.md`
  - Minor ordering changes of content in the repository [README.md](/README.md).