### PR TITLE
Added the ability to edit the richtext of a selection, and an example app demonstrating how to do this.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2024-05-09
+
+### 🧰 Added
+- `@canva/design`
+  - Added the ability to edit richtext via the Selection API.
+- `examples`
+  - Added an example to demonstrate the new [Richtext Selection API](https://www.canva.dev/docs/apps/api/design-selection-register-on-change/) in `examples/richtext_replacement`.
+
+### 🔧 Changed
+- `@canva/app-ui-kit` 
+  - Upgraded `app-ui-kit` to version `3.5.1`. Please see the [changelog](https://www.canva.dev/docs/apps/app-ui-kit/changelog/) for the list of changes.
+
 ## 2024-05-06
 
 ### 🧰 Added

--- a/examples/richtext_replacement/app.tsx
+++ b/examples/richtext_replacement/app.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from "react";
+import { Button, Rows, Text } from "@canva/app-ui-kit";
+import { selection, SelectionEvent } from "@canva/preview/design";
+import styles from "styles/components.css";
+
+export const App = () => {
+  const [selectionState, setSelectionState] = useState<
+    SelectionEvent<"richtext">
+  >({
+    count: 0,
+    scope: "richtext",
+    read: () =>
+      Promise.resolve({
+        contents: [],
+        save: () => Promise.resolve(),
+      }),
+  });
+
+  useEffect(() => {
+    selection.registerOnChange({
+      scope: "richtext",
+      onChange: (evt) => {
+        if (evt.count > 0) {
+          setSelectionState(evt);
+        }
+      },
+    });
+  }, []);
+
+  const updateFormatting = async () => {
+    const draft = await selectionState!.read();
+    for (const richtext of draft.contents) {
+      const regions = await richtext.readTextRegions();
+      let index = 0;
+      regions.forEach((region) => {
+        richtext.formatText(
+          { index, length: region.text.length },
+          {
+            fontWeight:
+              region.formatting?.fontWeight === "bold" ? "normal" : "bold",
+          }
+        );
+        index = index + region.text.length;
+      });
+    }
+    await draft.save();
+  };
+
+  const appendText = async () => {
+    const draft = await selectionState!.read();
+    draft.contents.forEach((richtext) => richtext.appendText("!"));
+    await draft.save();
+  };
+
+  const replaceText = async () => {
+    const draft = await selectionState!.read();
+    for (const richtext of draft.contents) {
+      const plaintext = await richtext.readPlaintext();
+      richtext.replaceText(
+        { index: 0, length: plaintext.length },
+        "Hello World",
+        { decoration: "underline" }
+      );
+    }
+    await draft.save();
+  };
+
+  return (
+    <div className={styles.scrollContainer}>
+      <Rows spacing="2u">
+        <Text>
+          This example demonstrates how apps can replace the selected text.
+          Select a text in the editor to begin.
+        </Text>
+        <Button
+          variant="primary"
+          onClick={updateFormatting}
+          disabled={selectionState.count === 0}
+        >
+          Toggle boldness
+        </Button>
+        <Button
+          variant="primary"
+          onClick={appendText}
+          disabled={selectionState.count === 0}
+        >
+          Append "!"
+        </Button>
+        <Button
+          variant="primary"
+          onClick={replaceText}
+          disabled={selectionState.count === 0}
+        >
+          Replace with underlined "Hello World"
+        </Button>
+      </Rows>
+    </div>
+  );
+};

--- a/examples/richtext_replacement/index.tsx
+++ b/examples/richtext_replacement/index.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+import "@canva/app-ui-kit/styles.css";
+import { AppUiProvider } from "@canva/app-ui-kit";
+
+const root = createRoot(document.getElementById("root")!);
+function render() {
+  root.render(
+    <AppUiProvider>
+      <App />
+    </AppUiProvider>
+  );
+}
+
+render();
+
+if (module.hot) {
+  module.hot.accept("./app", render);
+}

--- a/examples/richtext_replacement/package.json
+++ b/examples/richtext_replacement/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "richtext_replacement",
+  "description": "An example app demonstrating how apps can replace the selected text.",
+  "author": "Canva Pty Ltd.",
+  "license": "Please refer to the LICENSE.md file in the root directory"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "examples/*"
       ],
       "dependencies": {
-        "@canva/app-ui-kit": "^3.4.0",
+        "@canva/app-ui-kit": "^3.5.1",
         "@canva/asset": "^1.5.0",
         "@canva/design": "^1.8.0",
         "@canva/error": "^1.1.0",
@@ -405,6 +405,9 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "examples/richtext_replacement": {
+      "license": "Please refer to the LICENSE.md file in the root directory"
     },
     "examples/sdk/experimental": {
       "extraneous": true
@@ -2440,16 +2443,16 @@
       }
     },
     "node_modules/@canva/app-ui-kit": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@canva/app-ui-kit/-/app-ui-kit-3.4.0.tgz",
-      "integrity": "sha512-m+1DRijt5fAPIjgv32QXvMPeQ3cVM4UCqzDOFkIXpLeHDih+edbULb1+1/Esmla8vnc5dgUBQHEw5XRLKxg0OQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@canva/app-ui-kit/-/app-ui-kit-3.5.1.tgz",
+      "integrity": "sha512-01/xTMOLyUBkex0auG+HX2iL64o3AC2Iy8aW2sJmFb2bUX6WUM3EKW0+Y2fn5+5pXdrrJ7DSOKNFUADNDphrIQ==",
       "dependencies": {
         "@seznam/compose-react-refs": "^1.0.4",
         "classnames": "^2.2.5",
         "intl-messageformat": "^10.5.4",
         "intl-pluralrules": "^2.0.1",
         "make-plural": "^7.3.0",
-        "mobx": "6.8.0",
+        "mobx": "6.12.3",
         "mobx-react": "^7.5.2",
         "mobx-utils": "^6.0.5",
         "normalize-scroll-left": "^0.2.1",
@@ -2459,6 +2462,7 @@
         "react-measure": "^2.5.2",
         "react-transition-group": "^4.4.1",
         "resize-observer-polyfill": "^1.5.1",
+        "seedrandom": "^3.0.5",
         "smoothscroll-polyfill": "^0.4.4",
         "tslib": "^2.5.0"
       },
@@ -8626,9 +8630,9 @@
       }
     },
     "node_modules/mobx": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.8.0.tgz",
-      "integrity": "sha512-+o/DrHa4zykFMSKfS8Z+CPSEg5LW9tSNGTuN8o6MF1GKxlfkSHSeJn5UtgxvPkGgaouplnrLXCF+duAsmm6FHQ==",
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.12.3.tgz",
+      "integrity": "sha512-c8NKkO4R2lShkSXZ2Ongj1ycjugjzFFo/UswHBnS62y07DMcTc9Rvo03/3nRyszIvwPNljlkd4S828zIBv/piw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -10319,6 +10323,10 @@
         "node": ">= 4"
       }
     },
+    "node_modules/richtext_replacement": {
+      "resolved": "examples/richtext_replacement",
+      "link": true
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -10411,6 +10419,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/select-hose": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "examples/*"
   ],
   "dependencies": {
-    "@canva/app-ui-kit": "^3.4.0",
+    "@canva/app-ui-kit": "^3.5.1",
     "@canva/asset": "^1.5.0",
     "@canva/design": "^1.8.0",
     "@canva/error": "^1.1.0",

--- a/sdk/preview/design/index.d.ts
+++ b/sdk/preview/design/index.d.ts
@@ -161,6 +161,24 @@ export declare type AudioTrack = {
 };
 
 /**
+ * @beta
+ * The boundaries of a rich text region.
+ */
+export declare type Bounds = {
+  /**
+   * The index of the character from which the region starts.
+   *
+   * @remarks
+   * A value of `0` means the region starts from the first character.
+   */
+  index: number;
+  /**
+   * The length of the text region.
+   */
+  length: number;
+};
+
+/**
  * @public
  * The dimensions, position, and rotation of an element.
  *
@@ -265,7 +283,7 @@ export declare type DesignOverlay = {
 };
 
 /**
- * @public
+ * @beta
  * Provides methods for interacting with the user's selected content, such as images or text.
  */
 export declare type DesignSelection = {
@@ -1160,13 +1178,146 @@ export declare function requestExport(
 ): Promise<ExportResponse>;
 
 /**
- * @public
+ * @beta
+ *
+ * Formatting values for richtext
+ */
+export declare type RichtextFormatting = {
+  /**
+   * @public
+   * A reference to the font to use for this text element.
+   */
+  fontRef?: FontRef;
+  /**
+   * The size of the text, in pixels.
+   *
+   * @remarks
+   * This must be an integer between 1 and 1000.
+   * In the UI of the Canva editor, this number is shown as points (pts), not pixels.
+   */
+  fontSize?: number;
+  /**
+   * The alignment of the text.
+   * @defaultValue 'start'
+   */
+  textAlign?: "start" | "center" | "end" | "justify";
+  /**
+   * The color of the text as a hex code.
+   *
+   * @remarks
+   * The hex code must include all six characters and be prefixed with a # symbol
+   * (e.g. #ff0099). The default value is #000000.
+   */
+  color?: string;
+  /**
+   * The weight (thickness) of the font.
+   *
+   * @remark
+   * The available font weights depend on the font.
+   *
+   * @defaultValue 'normal'
+   */
+  fontWeight?: FontWeight;
+  /**
+   * The style of the font.
+   * @defaultValue 'normal'
+   */
+  fontStyle?: "normal" | "italic";
+  /**
+   * The decoration of the text.
+   * @defaultValue 'none'
+   */
+  decoration?: "none" | "underline";
+  /**
+   * The strikethrough of the text.
+   * @defaultValue 'none'
+   */
+  strikethrough?: "none" | "strikethrough";
+  /**
+   * A url that the underlying text will link to
+   */
+  link?: string;
+  /**
+   * The list indentation level of the current paragraph.
+   */
+  listLevel?: number;
+  /**
+   * The appearance of the marker for list items.
+   *
+   * @remarks
+   * This property only has an effect if `listLevel` is a number greater than 0.
+   *
+   * @defaultValue 'none'
+   */
+  listMarker?:
+    | "none"
+    | "disc"
+    | "circle"
+    | "square"
+    | "decimal"
+    | "lower-alpha"
+    | "lower-roman"
+    | "checked"
+    | "unchecked";
+};
+
+/**
+ * @beta
+ *
+ * An object containing rich text which exposes methods to manipulate the text.
+ * This is generated from a selection, with a range created for each instance of text in the selection.
+ * For example, if a table is currently selected, a range will be created for each cell.
+ * If only part of the text of an element is selected, then only that part will be represented in the range.
+ */
+export declare type RichtextRange = {
+  /**
+   * Formats a region of the selected rich text.
+   * @param bounds - The region of text to apply the formatting.
+   * @param formatting - The formatting to apply to the region of text.
+   */
+  formatText(bounds: Bounds, formatting: RichtextFormatting): void;
+  /**
+   * Appends characters to the selected rich text.
+   * @param characters - The characters to append to the selected rich text.
+   * @param formatting - The formatting to apply to the appended text.
+   */
+  appendText(characters: string, formatting?: RichtextFormatting): void;
+  /**
+   * Replaces a region of the selected rich text with the specified characters.
+   * @param bounds - The region of text to be replaced.
+   * @param characters - The replacement characters.
+   * @param formatting - The formatting to apply to the replaced text.
+   */
+  replaceText(
+    bounds: Bounds,
+    characters: string,
+    formatting?: RichtextFormatting
+  ): void;
+  /**
+   * Returns the current draft of the selected rich text as plain text.
+   *
+   * @remarks
+   * This includes any changes to the text that have not been committed.
+   */
+  readPlaintext(): Promise<string>;
+  /**
+   * Returns the current draft of the selected rich text as an array of text regions.
+   * Each region is an object that contains the text itself and its formatting.
+   *
+   * @remarks
+   * This array includes any changes to the text that have not been committed.
+   */
+  readTextRegions(): Promise<TextRegion[]>;
+};
+
+/**
+ * @beta
  * An alias for the DesignSelection interface, providing access to design selection related functionality
  */
 export declare const selection: DesignSelection;
 
 /**
- * @public
+ * @beta
  * Information about the user's selection. To access the selected content, call the `read` method.
  */
 export declare interface SelectionEvent<Scope extends SelectionScope> {
@@ -1201,13 +1352,17 @@ export declare interface SelectionEvent<Scope extends SelectionScope> {
 }
 
 /**
- * @public
+ * @beta
  * The type of content that apps can detect selection changes on.
  */
-export declare type SelectionScope = "plaintext" | "image";
+export declare type SelectionScope =
+  | "plaintext"
+  | "image"
+  | "video"
+  | "richtext";
 
 /**
- * @public
+ * @beta
  * The selected content.
  *
  * @remarks
@@ -1232,6 +1387,19 @@ export declare type SelectionValue<Scope extends SelectionScope> = {
      */
     ref: ImageRef;
   };
+  /**
+   * The selected content when {@link SelectionScope} is `"video"`.
+   */
+  ["video"]: {
+    /**
+     * A unique identifier that points to an video asset in Canva's backend.
+     */
+    ref: VideoRef;
+  };
+  /**
+   * The selected content when {@link SelectionScope} is `"richtext"`.
+   */
+  ["richtext"]: RichtextRange;
 }[Scope];
 
 /**
@@ -1317,7 +1485,7 @@ export declare type TextAttributes = {
    * The alignment of the text.
    * @defaultValue 'start'
    */
-  textAlign?: "start" | "center" | "end";
+  textAlign?: "start" | "center" | "end" | "justify";
   /**
    * The color of the text as a hex code.
    *
@@ -1365,7 +1533,7 @@ export declare type TextDragConfig = {
    * The alignment of the text.
    * @defaultValue 'start'
    */
-  textAlign?: "start" | "center" | "end";
+  textAlign?: "start" | "center" | "end" | "justify";
   /**
    * The weight of the font.
    * @defaultValue 'normal'
@@ -1386,6 +1554,21 @@ export declare type TextDragConfig = {
    * A unique identifier that references a font asset in Canva's backend.
    */
   fontRef?: FontRef;
+};
+
+/**
+ * @beta
+ * A region of rich text.
+ */
+export declare type TextRegion = {
+  /**
+   * The plain text content of the region.
+   */
+  text: string;
+  /**
+   * The formatting of the region.
+   */
+  formatting?: Partial<RichtextFormatting>;
 };
 
 /**

--- a/utils/backend/jwt_middleware/tests/jwt_middleware.tests.ts
+++ b/utils/backend/jwt_middleware/tests/jwt_middleware.tests.ts
@@ -589,7 +589,7 @@ describe("getTokenFromQueryString", () => {
 
   describe("When the 'canva_user_token' query parameter is not a string", () => {
     beforeEach(() => {
-      req.query.canva_user_token = 10 as any;
+      req.query.canva_user_token = 10 as unknown as string;
     });
 
     it(`Throws a JWTAuthorizationError with message = 'Missing "canva_user_token" query parameter'`, async () => {


### PR DESCRIPTION
## 2024-05-09

### 🧰 Added
- `@canva/design`
  - Added the ability to edit richtext via the Selection API.
- `examples`
  - Added an example to demonstrate the new [Richtext Selection API](https://www.canva.dev/docs/apps/api/design-selection-register-on-change/) in `examples/richtext_replacement`.

### 🔧 Changed
- `@canva/app-ui-kit` 
  - Upgraded `app-ui-kit` to version `3.5.1`. Please see the [changelog](https://www.canva.dev/docs/apps/app-ui-kit/changelog/) for the list of changes.