### PR TITLE
Added the ability to filter by fontRefs in findFonts API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2024-06-20
+
+### 🔧 Changed
+- `@canva/asset`
+  - Upgraded to version `1.6.0` which has the following changes:
+    - Added the ability to filter by fontRefs in [findFonts API](https://www.canva.dev/docs/apps/api/asset-find-fonts/#filtering).
+
 ## 2024-06-04
 
 ### 🧰 Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "dependencies": {
         "@canva/app-ui-kit": "^3.5.1",
-        "@canva/asset": "^1.5.0",
+        "@canva/asset": "^1.6.0",
         "@canva/design": "^1.9.0",
         "@canva/error": "^1.1.0",
         "@canva/platform": "^1.1.0",
@@ -2472,9 +2472,9 @@
       }
     },
     "node_modules/@canva/asset": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@canva/asset/-/asset-1.5.0.tgz",
-      "integrity": "sha512-szmOhi03sN+6PxbvKHrjnBGG7o8pneuNvNuikMDtIaKW77K/LhplWABbNvFNHqmQESXOEjOhzSQuV6D10oWTzg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@canva/asset/-/asset-1.6.0.tgz",
+      "integrity": "sha512-u4pqVwsOap8utIhqHaxtCeDK4BKYBtoo6MpxfpTKCrhx4EIUnQeMPifmcB7Zi+nynJVWxkKwuxyXrDQRfe9o1A==",
       "peerDependencies": {
         "@canva/error": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@canva/app-ui-kit": "^3.5.1",
-    "@canva/asset": "^1.5.0",
+    "@canva/asset": "^1.6.0",
     "@canva/design": "^1.9.0",
     "@canva/error": "^1.1.0",
     "@canva/platform": "^1.1.0",

--- a/sdk/preview/asset/index.d.ts
+++ b/sdk/preview/asset/index.d.ts
@@ -152,9 +152,10 @@ export declare type Dimensions = {
 };
 
 /**
- * @beta
+ * @public
  * Lists a curated selection of fonts available for use within Canva when no `options` is provided,
  * otherwise performs filtering based on the criteria specified in the `options`.
+ *
  * @remarks
  * To list all available fonts, please use the `requestFontSelection` method.
  */
@@ -163,7 +164,7 @@ export declare function findFonts(
 ): Promise<FindFontsResponse>;
 
 /**
- * @beta
+ * @public
  * Arguments to the findFonts method.
  */
 export declare type FindFontsOptions = {


### PR DESCRIPTION
## 2024-06-20

### 🔧 Changed
- `@canva/asset`
  - Upgraded to version `1.6.0` which has the following changes:
    - Added the ability to filter by fontRefs in [findFonts API](https://www.canva.dev/docs/apps/api/asset-find-fonts/#filtering).