### PR TITLE
Bump `@canva/app-ui-kit` to version `3.6.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: NPM ci
         run: npm ci
+      - name: npm run test
+        run: npm run test
       - name: Run prettier
         run: npm run format:check
       - name: Lint types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2024-07-03
+
+### 🧰 Added
+- An `npm run test` step in `ci.yml`.
+
+### 🐞 Fixed
+- Fix of date test in `utils/backend/jwt_middleware`.
+- Updated some dependencies by running `npm audit fix`.
+
+### 🔧 Changed
+- `@canva/app-ui-kit` 
+  - Upgraded `app-ui-kit` to version `3.6.0`. Please see the [changelog](https://www.canva.dev/docs/apps/app-ui-kit/changelog/) for the list of changes.
+- Upgraded `react`, `react-dom` and their type packages to version `18.3.1`.
+- Removed unnecessary react imports by switching to `jsx-react`
+
 ## 2024-06-20
 
 ### 🔧 Changed

--- a/examples/app_element_children/app.tsx
+++ b/examples/app_element_children/app.tsx
@@ -11,7 +11,7 @@ import type {
   NativeShapeElementWithBox,
 } from "@canva/design";
 import { initAppElement } from "@canva/design";
-import React from "react";
+import { useEffect, useState } from "react";
 import styles from "styles/components.css";
 
 // The data that will be attached to the app element
@@ -66,14 +66,14 @@ const appElementClient = initAppElement<AppElementData>({
 });
 
 export const App = () => {
-  const [state, setState] = React.useState<UIState>(initialState);
+  const [state, setState] = useState<UIState>(initialState);
   const { width, height, rows, columns, spacing, rotation } = state;
   const disabled = width < 1 || height < 1 || rows < 1 || columns < 1;
 
   // This callback runs when the app element's data is modified or when the
   // user selects an app element. In both situations, we can use this callback
   // to update the state of the UI to reflect the latest data.
-  React.useEffect(() => {
+  useEffect(() => {
     appElementClient.registerOnElementChange((appElement) => {
       setState(appElement ? appElement.data : initialState);
     });

--- a/examples/app_element_children/index.tsx
+++ b/examples/app_element_children/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/app_embed_elements/app.tsx
+++ b/examples/app_embed_elements/app.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { initAppElement } from "@canva/design";
 import {
   Button,
@@ -9,6 +8,7 @@ import {
   TextInput,
 } from "@canva/app-ui-kit";
 import styles from "styles/components.css";
+import { useEffect, useState } from "react";
 
 type AppElementData = {
   url: string;
@@ -31,11 +31,11 @@ const appElementClient = initAppElement<AppElementData>({
 });
 
 export const App = () => {
-  const [state, setState] = React.useState<UIState>(initialState);
+  const [state, setState] = useState<UIState>(initialState);
   const { url, width, height } = state;
   const disabled = url?.trim().length < 1 || !width || !height;
 
-  React.useEffect(() => {
+  useEffect(() => {
     appElementClient.registerOnElementChange((appElement) => {
       setState(appElement ? appElement.data : initialState);
     });

--- a/examples/app_embed_elements/index.tsx
+++ b/examples/app_embed_elements/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/app_image_elements/app.tsx
+++ b/examples/app_image_elements/app.tsx
@@ -12,7 +12,7 @@ import { initAppElement } from "@canva/design";
 import cat from "assets/images/cat.jpg";
 import dog from "assets/images/dog.jpg";
 import rabbit from "assets/images/rabbit.jpg";
-import React from "react";
+import { useEffect, useState, useCallback } from "react";
 import baseStyles from "styles/components.css";
 import { upload } from "@canva/asset";
 
@@ -68,8 +68,8 @@ const appElementClient = initAppElement<AppElementData>({
 });
 
 export const App = () => {
-  const [loading, setLoading] = React.useState(false);
-  const [state, setState] = React.useState<UIState>(initialState);
+  const [loading, setLoading] = useState(false);
+  const [state, setState] = useState<UIState>(initialState);
   const { imageId, width, height, rotation } = state;
   const disabled = loading || !imageId || imageId.trim().length < 1;
 
@@ -91,7 +91,7 @@ export const App = () => {
     };
   });
 
-  const addOrUpdateImage = React.useCallback(async () => {
+  const addOrUpdateImage = useCallback(async () => {
     setLoading(true);
     try {
       if (!images[state.imageId].imageRef) {
@@ -113,7 +113,7 @@ export const App = () => {
     }
   }, [state]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     appElementClient.registerOnElementChange((appElement) => {
       setState(appElement ? appElement.data : initialState);
     });

--- a/examples/app_image_elements/index.tsx
+++ b/examples/app_image_elements/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/app_shape_elements/app.tsx
+++ b/examples/app_shape_elements/app.tsx
@@ -12,7 +12,7 @@ import {
   Title,
 } from "@canva/app-ui-kit";
 import { initAppElement } from "@canva/design";
-import React from "react";
+import { useEffect, useState } from "react";
 import styles from "styles/components.css";
 
 type AppElementData = {
@@ -64,11 +64,11 @@ const appElementClient = initAppElement<AppElementData>({
 });
 
 export const App = () => {
-  const [state, setState] = React.useState<UIState>(initialState);
+  const [state, setState] = useState<UIState>(initialState);
   const { paths, viewBox, width, height, rotation } = state;
   const disabled = paths.length < 1;
 
-  React.useEffect(() => {
+  useEffect(() => {
     appElementClient.registerOnElementChange((appElement) => {
       setState(appElement ? appElement.data : initialState);
     });

--- a/examples/app_shape_elements/index.tsx
+++ b/examples/app_shape_elements/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/app_text_elements/app.tsx
+++ b/examples/app_text_elements/app.tsx
@@ -11,7 +11,7 @@ import {
   Title,
 } from "@canva/app-ui-kit";
 import { initAppElement, FontWeight, TextAttributes } from "@canva/design";
-import React from "react";
+import { useEffect, useState } from "react";
 import styles from "styles/components.css";
 
 type AppElementData = {
@@ -56,7 +56,7 @@ const appElementClient = initAppElement<AppElementData>({
 });
 
 export const App = () => {
-  const [state, setState] = React.useState<UIState>(initialState);
+  const [state, setState] = useState<UIState>(initialState);
 
   const {
     text,
@@ -72,7 +72,7 @@ export const App = () => {
 
   const disabled = text.trim().length < 1 || color.trim().length < 1;
 
-  React.useEffect(() => {
+  useEffect(() => {
     appElementClient.registerOnElementChange((appElement) => {
       setState(appElement ? appElement.data : initialState);
     });

--- a/examples/app_text_elements/index.tsx
+++ b/examples/app_text_elements/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/asset_upload/app.tsx
+++ b/examples/asset_upload/app.tsx
@@ -1,7 +1,6 @@
 import { Button, Rows, Text } from "@canva/app-ui-kit";
 import { upload } from "@canva/asset";
 import { addAudioTrack, addNativeElement } from "@canva/design";
-import React from "react";
 import styles from "styles/components.css";
 
 export const App = () => {

--- a/examples/asset_upload/index.tsx
+++ b/examples/asset_upload/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import "@canva/app-ui-kit/styles.css";

--- a/examples/authentication/app.tsx
+++ b/examples/authentication/app.tsx
@@ -1,7 +1,7 @@
 import type { Authentication } from "@canva/user";
 import { auth } from "@canva/user";
 import { Box, Button, Rows, Text, Title } from "@canva/app-ui-kit";
-import React from "react";
+import { useState, useEffect } from "react";
 import styles from "styles/components.css";
 
 type State = "authenticated" | "not_authenticated" | "checking" | "error";
@@ -47,9 +47,9 @@ const checkAuthenticationStatus = async (
 
 export const App = () => {
   // Keep track of the user's authentication status.
-  const [state, setState] = React.useState<State>("checking");
+  const [state, setState] = useState<State>("checking");
 
-  React.useEffect(() => {
+  useEffect(() => {
     checkAuthenticationStatus(auth).then((status) => {
       setState(status);
     });

--- a/examples/authentication/index.tsx
+++ b/examples/authentication/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/color/app.tsx
+++ b/examples/color/app.tsx
@@ -5,11 +5,11 @@ import {
   ColorSelectionScope,
   openColorSelector,
 } from "@canva/preview/asset";
-import React from "react";
+import { useState } from "react";
 import styles from "styles/components.css";
 
 export const App = () => {
-  const [color, setColor] = React.useState<string | undefined>(undefined);
+  const [color, setColor] = useState<string | undefined>(undefined);
   const onColorSelect = async <T extends ColorSelectionScope>(
     e: ColorSelectionEvent<T>
   ) => {

--- a/examples/color/index.tsx
+++ b/examples/color/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";
 import "@canva/app-ui-kit/styles.css";

--- a/examples/data_provider_basic/app.tsx
+++ b/examples/data_provider_basic/app.tsx
@@ -1,7 +1,7 @@
 import { Rows, Text, Title, tokens } from "@canva/app-ui-kit";
 import type { DataTable, DataTableColumn } from "@canva/preview/data";
 import { onSelectDataTable } from "@canva/preview/data";
-import React from "react";
+import { useEffect } from "react";
 import styles from "styles/components.css";
 
 const breedsDataTable: DataTable = {
@@ -38,7 +38,7 @@ const numRows = breedsDataTable.columns.sort(
 
 // An app that uses the Data SDK to return a single data table to a consumer (e.g. Bulk Create)
 export const App = () => {
-  React.useEffect(() => {
+  useEffect(() => {
     // This callback runs when Bulk Create wants to receive data
     onSelectDataTable(async (opts) => {
       // This callback returns the single data table to Bulk Create

--- a/examples/data_provider_basic/index.tsx
+++ b/examples/data_provider_basic/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/data_provider_options/app.tsx
+++ b/examples/data_provider_options/app.tsx
@@ -1,7 +1,7 @@
 import { Button, Rows, Text } from "@canva/app-ui-kit";
 import type { DataTable } from "@canva/preview/data";
 import { onSelectDataTable } from "@canva/preview/data";
-import React from "react";
+import { useState, useEffect } from "react";
 import styles from "styles/components.css";
 
 const properties = {
@@ -62,9 +62,9 @@ type State = {
 // An app that exposes multiple data tables, allows users to select a data
 // table, and returns the selected data table to a consumer (e.g. Bulk Create)
 export const App = () => {
-  const [state, setState] = React.useState<State>({});
+  const [state, setState] = useState<State>({});
 
-  React.useEffect(() => {
+  useEffect(() => {
     // This callback runs when Bulk Create wants to receive data
     onSelectDataTable(async (opts) => {
       setState((prevState) => {

--- a/examples/data_provider_options/index.tsx
+++ b/examples/data_provider_options/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/design_token/app.tsx
+++ b/examples/design_token/app.tsx
@@ -6,7 +6,7 @@ import {
   Text,
   TextInput,
 } from "@canva/app-ui-kit";
-import React, { useEffect, useState } from "react";
+import { useState, useEffect } from "react";
 import styles from "styles/components.css";
 import { auth } from "@canva/user";
 import { getDefaultPageDimensions, getDesignToken } from "@canva/design";
@@ -22,8 +22,8 @@ type DesignData = {
 export const App = () => {
   const [title, setTitle] = useState("");
   const [state, setState] = useState<"loading" | "idle">("idle");
-  const [error, setError] = useState<string | undefined>();
   const [designData, setDesignData] = useState<DesignData | undefined>();
+  const [error, setError] = useState<string | undefined>();
 
   const getDesignData = async () => {
     setState("loading");

--- a/examples/design_token/index.tsx
+++ b/examples/design_token/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/digital_asset_management/app.tsx
+++ b/examples/digital_asset_management/app.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useState, useEffect } from "react";
 import { SearchableListView } from "@canva/app-components";
 import { Alert, Box, Button, LoadingIndicator, Rows } from "@canva/app-ui-kit";
 import "@canva/app-ui-kit/styles.css";
@@ -55,17 +55,16 @@ const checkAuthenticationStatus = async (
 
 export function App() {
   // Keep track of the user's authentication status.
-  const [authState, setAuthState] =
-    React.useState<AuthenticationState>("checking");
+  const [authState, setAuthState] = useState<AuthenticationState>("checking");
 
-  React.useEffect(() => {
+  useEffect(() => {
     setAuthState("checking");
     checkAuthenticationStatus(auth).then((status) => {
       setAuthState(status);
     });
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (authState === "not_authenticated") {
       startAuthenticationFlow();
     }

--- a/examples/digital_asset_management/index.tsx
+++ b/examples/digital_asset_management/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/drag_and_drop_audio/app.tsx
+++ b/examples/drag_and_drop_audio/app.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Rows, Text, AudioCard, AudioContextProvider } from "@canva/app-ui-kit";
 import { upload } from "@canva/asset";
 import { addAudioTrack, ui } from "@canva/design";

--- a/examples/drag_and_drop_audio/index.tsx
+++ b/examples/drag_and_drop_audio/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/drag_and_drop_embed/app.tsx
+++ b/examples/drag_and_drop_embed/app.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Rows, Text, EmbedCard } from "@canva/app-ui-kit";
 import styles from "styles/components.css";
 import { addNativeElement, ui } from "@canva/design";

--- a/examples/drag_and_drop_embed/index.tsx
+++ b/examples/drag_and_drop_embed/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/drag_and_drop_image/app.tsx
+++ b/examples/drag_and_drop_image/app.tsx
@@ -2,7 +2,6 @@ import { Rows, Text, Title, ImageCard } from "@canva/app-ui-kit";
 import { upload } from "@canva/asset";
 import { addNativeElement, ui } from "@canva/design";
 import dog from "assets/images/dog.jpg";
-import React from "react";
 import styles from "styles/components.css";
 
 const uploadExternalImage = () => {

--- a/examples/drag_and_drop_image/index.tsx
+++ b/examples/drag_and_drop_image/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/drag_and_drop_text/app.tsx
+++ b/examples/drag_and_drop_text/app.tsx
@@ -11,7 +11,7 @@ import {
   FontWeight,
   TextAttributes,
 } from "@canva/design";
-import React from "react";
+import { useState } from "react";
 import styles from "styles/components.css";
 
 type DraggableTextProperties = {
@@ -24,13 +24,14 @@ type DraggableTextProperties = {
 const content = "Add a little bit of body text";
 
 export const App = () => {
-  const [{ fontStyle, fontWeight, decoration, textAlign }, setState] =
-    React.useState<Required<DraggableTextProperties>>({
-      decoration: "none",
-      fontStyle: "normal",
-      fontWeight: "normal",
-      textAlign: "start",
-    });
+  const [{ fontStyle, fontWeight, decoration, textAlign }, setState] = useState<
+    Required<DraggableTextProperties>
+  >({
+    decoration: "none",
+    fontStyle: "normal",
+    fontWeight: "normal",
+    textAlign: "start",
+  });
 
   const onDragStart = (event: React.DragEvent<HTMLElement>) => {
     ui.startDrag(event, {

--- a/examples/drag_and_drop_text/index.tsx
+++ b/examples/drag_and_drop_text/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/drag_and_drop_video/app.tsx
+++ b/examples/drag_and_drop_video/app.tsx
@@ -1,7 +1,6 @@
 import { Rows, Text, Title, VideoCard } from "@canva/app-ui-kit";
 import { upload } from "@canva/asset";
 import { VideoDragConfig, addNativeElement, ui } from "@canva/design";
-import React from "react";
 import styles from "styles/components.css";
 
 const uploadVideo = () => {

--- a/examples/drag_and_drop_video/index.tsx
+++ b/examples/drag_and_drop_video/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/export/app.tsx
+++ b/examples/export/app.tsx
@@ -7,7 +7,7 @@ import {
 } from "@canva/app-ui-kit";
 import type { ExportResponse } from "@canva/design";
 import { requestExport } from "@canva/design";
-import React, { useState } from "react";
+import { useState } from "react";
 import styles from "styles/components.css";
 
 export const App = () => {

--- a/examples/export/index.tsx
+++ b/examples/export/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/fetch/app.tsx
+++ b/examples/fetch/app.tsx
@@ -7,7 +7,7 @@ import {
   Title,
 } from "@canva/app-ui-kit";
 import { auth } from "@canva/user";
-import React, { useState } from "react";
+import { useState } from "react";
 import styles from "styles/components.css";
 
 const BACKEND_URL = `${BACKEND_HOST}/custom-route`;

--- a/examples/fetch/index.tsx
+++ b/examples/fetch/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/fonts/app.tsx
+++ b/examples/fonts/app.tsx
@@ -18,7 +18,7 @@ import {
   requestFontSelection,
 } from "@canva/asset";
 import { addNativeElement } from "@canva/design";
-import React, { useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import styles from "styles/components.css";
 
 type TextConfig = {
@@ -45,15 +45,11 @@ const fontStyleOptions: {
 ];
 
 export const App = () => {
-  const [textConfig, setTextConfig] = React.useState<TextConfig>(initialConfig);
-  const [selectedFont, setSelectedFont] = React.useState<Font | undefined>(
-    undefined
-  );
-  const [availableFonts, setAvailableFonts] = React.useState<readonly Font[]>(
-    []
-  );
+  const [textConfig, setTextConfig] = useState<TextConfig>(initialConfig);
+  const [selectedFont, setSelectedFont] = useState<Font | undefined>(undefined);
+  const [availableFonts, setAvailableFonts] = useState<readonly Font[]>([]);
 
-  const fetchFonts = React.useCallback(async () => {
+  const fetchFonts = useCallback(async () => {
     const response = await findFonts();
     setAvailableFonts(response.fonts);
   }, [setAvailableFonts]);

--- a/examples/fonts/index.tsx
+++ b/examples/fonts/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/image_editing_overlay/app.tsx
+++ b/examples/image_editing_overlay/app.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { appProcess } from "@canva/platform";
 import { ObjectPanel } from "./object_panel";
 import { Overlay } from "./overlay";

--- a/examples/image_editing_overlay/index.tsx
+++ b/examples/image_editing_overlay/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";
 import "@canva/app-ui-kit/styles.css";

--- a/examples/image_editing_overlay/object_panel.tsx
+++ b/examples/image_editing_overlay/object_panel.tsx
@@ -1,5 +1,5 @@
 import { Rows, FormField, Button, Slider } from "@canva/app-ui-kit";
-import * as React from "react";
+import { useState } from "react";
 import styles from "styles/components.css";
 import { appProcess } from "@canva/platform";
 import { useOverlay } from "utils/use_overlay_hook";
@@ -20,7 +20,7 @@ export const ObjectPanel = () => {
     open,
     close: closeOverlay,
   } = useOverlay<"image_selection", CloseOpts>("image_selection");
-  const [state, setState] = React.useState<UIState>(initialState);
+  const [state, setState] = useState<UIState>(initialState);
 
   const openOverlay = async () => {
     open({

--- a/examples/image_editing_overlay/overlay.tsx
+++ b/examples/image_editing_overlay/overlay.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useEffect, useRef } from "react";
 import { LaunchParams } from "./app";
 import { getTemporaryUrl, upload } from "@canva/asset";
 import { useSelection } from "utils/use_selection_hook";
@@ -22,13 +22,13 @@ export const Overlay = (props: OverlayProps) => {
   const { context: appContext } = props;
   const selection = useSelection("image");
 
-  const canvasRef = React.useRef<HTMLCanvasElement>(null);
-  const isDragginRef = React.useRef<boolean>();
-  const uiStateRef = React.useRef<UIState>({
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const isDraggingRef = useRef<boolean>();
+  const uiStateRef = useRef<UIState>({
     brushSize: 7,
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!selection || selection.count !== 1) {
       return;
     }
@@ -89,11 +89,11 @@ export const Overlay = (props: OverlayProps) => {
     });
 
     canvas.addEventListener("pointerdown", (e) => {
-      isDragginRef.current = true;
+      isDraggingRef.current = true;
     });
 
     canvas.addEventListener("pointermove", (e) => {
-      if (isDragginRef.current) {
+      if (isDraggingRef.current) {
         const mousePos = getCanvasMousePosition(canvas, e);
         context.fillStyle = "white";
         context.beginPath();
@@ -109,7 +109,7 @@ export const Overlay = (props: OverlayProps) => {
     });
 
     canvas.addEventListener("pointerup", () => {
-      isDragginRef.current = false;
+      isDraggingRef.current = false;
     });
 
     return void appProcess.current.setOnDispose<CloseOpts>(
@@ -134,7 +134,7 @@ export const Overlay = (props: OverlayProps) => {
     );
   }, [selection]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // set up message handler
     return void appProcess.registerOnMessage((_, message) => {
       if (!message) {

--- a/examples/image_replacement/app.tsx
+++ b/examples/image_replacement/app.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import { useState } from "react";
 import { upload } from "@canva/asset";
 import { Button, Rows, Text } from "@canva/app-ui-kit";
 import { useSelection } from "utils/use_selection_hook";
 import styles from "styles/components.css";
 
 export const App = () => {
-  const [loading, setLoading] = React.useState(false);
+  const [loading, setLoading] = useState(false);
   const selection = useSelection("image");
 
   const updateImage = async () => {

--- a/examples/image_replacement/index.tsx
+++ b/examples/image_replacement/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";
 import "@canva/app-ui-kit/styles.css";

--- a/examples/masonry/app.tsx
+++ b/examples/masonry/app.tsx
@@ -6,7 +6,7 @@ import {
   Text,
   Placeholder,
 } from "@canva/app-ui-kit";
-import React from "react";
+import { useState, useRef } from "react";
 import styles from "styles/components.css";
 import { QueuedImage, upload } from "@canva/asset";
 import { addNativeElement, ui } from "@canva/design";
@@ -58,11 +58,11 @@ export const Placeholders = generatePlaceholders({
 ));
 
 export const App = () => {
-  const [images, setImages] = React.useState<Image[]>([]);
-  const [isFetching, setIsFetching] = React.useState(false);
-  const [page, setPage] = React.useState<number | undefined>(1);
+  const [images, setImages] = useState<Image[]>([]);
+  const [isFetching, setIsFetching] = useState(false);
+  const [page, setPage] = useState<number | undefined>(1);
 
-  const scrollContainerRef = React.useRef(null);
+  const scrollContainerRef = useRef(null);
 
   const fetchImages = async () => {
     if (isFetching || !page) {

--- a/examples/masonry/index.tsx
+++ b/examples/masonry/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/native_embed_elements/app.tsx
+++ b/examples/native_embed_elements/app.tsx
@@ -1,12 +1,10 @@
 import { addNativeElement } from "@canva/design";
-import React from "react";
+import { useState } from "react";
 import styles from "styles/components.css";
 import { Button, FormField, Rows, Text, TextInput } from "@canva/app-ui-kit";
 
 export const App = () => {
-  const [url, setUrl] = React.useState(
-    "https://www.youtube.com/watch?v=o-YBDTqX_ZU"
-  );
+  const [url, setUrl] = useState("https://www.youtube.com/watch?v=o-YBDTqX_ZU");
   const disabled = url.trim().length < 1;
 
   return (

--- a/examples/native_embed_elements/index.tsx
+++ b/examples/native_embed_elements/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/native_group_elements/app.tsx
+++ b/examples/native_group_elements/app.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button, Rows, Text } from "@canva/app-ui-kit";
 import { addNativeElement } from "@canva/design";
 import styles from "styles/components.css";

--- a/examples/native_group_elements/index.tsx
+++ b/examples/native_group_elements/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/native_image_elements/app.tsx
+++ b/examples/native_image_elements/app.tsx
@@ -11,7 +11,7 @@ import { addNativeElement } from "@canva/design";
 import cat from "assets/images/cat.jpg";
 import dog from "assets/images/dog.jpg";
 import rabbit from "assets/images/rabbit.jpg";
-import React from "react";
+import { useState, useCallback } from "react";
 import baseStyles from "styles/components.css";
 import { upload } from "@canva/asset";
 
@@ -31,8 +31,8 @@ const images = {
 };
 
 export const App = () => {
-  const [dataUrl, setDataUrl] = React.useState(dog);
-  const [isLoading, setIsLoading] = React.useState(false);
+  const [dataUrl, setDataUrl] = useState(dog);
+  const [isLoading, setIsLoading] = useState(false);
   const disabled = !dataUrl || dataUrl.trim().length < 1;
 
   const items = Object.entries(images).map(([key, value]) => {
@@ -48,7 +48,7 @@ export const App = () => {
     };
   });
 
-  const addImage = React.useCallback(async () => {
+  const addImage = useCallback(async () => {
     setIsLoading(true);
     try {
       const { ref } = await upload({

--- a/examples/native_image_elements/index.tsx
+++ b/examples/native_image_elements/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/native_shape_elements/app.tsx
+++ b/examples/native_shape_elements/app.tsx
@@ -12,7 +12,7 @@ import {
   Title,
 } from "@canva/app-ui-kit";
 import { addNativeElement } from "@canva/design";
-import React from "react";
+import { useState } from "react";
 import styles from "styles/components.css";
 
 type UIState = {
@@ -50,7 +50,7 @@ const initialState: UIState = {
 };
 
 export const App = () => {
-  const [state, setState] = React.useState<UIState>(initialState);
+  const [state, setState] = useState<UIState>(initialState);
 
   const { paths, viewBox } = state;
   const disabled = paths.length < 1;

--- a/examples/native_shape_elements/index.tsx
+++ b/examples/native_shape_elements/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/native_shape_elements_with_asset/app.tsx
+++ b/examples/native_shape_elements_with_asset/app.tsx
@@ -1,7 +1,6 @@
 import { addNativeElement } from "@canva/design";
 import { upload } from "@canva/asset";
 import { Button, Rows, Text } from "@canva/app-ui-kit";
-import React from "react";
 import styles from "styles/components.css";
 
 const HEART_PATH =

--- a/examples/native_shape_elements_with_asset/index.tsx
+++ b/examples/native_shape_elements_with_asset/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/native_table_elements/app.tsx
+++ b/examples/native_table_elements/app.tsx
@@ -1,5 +1,5 @@
 import { addNativeElement } from "@canva/preview/design";
-import React from "react";
+import { useState, useCallback } from "react";
 import styles from "styles/components.css";
 import {
   Alert,
@@ -161,9 +161,9 @@ const CellElement = ({
 
 export const App = () => {
   const state = useTable(initialState);
-  const [submissionError, setSubmissionError] = React.useState("");
+  const [submissionError, setSubmissionError] = useState("");
 
-  const onClick = React.useCallback(async () => {
+  const onClick = useCallback(async () => {
     try {
       await addNativeElement(state.toElement());
     } catch (e) {
@@ -173,7 +173,7 @@ export const App = () => {
     }
   }, [state]);
 
-  const onAddCell = React.useCallback(() => {
+  const onAddCell = useCallback(() => {
     state.cells = [...(state.cells || []), {}];
   }, []);
 

--- a/examples/native_table_elements/index.tsx
+++ b/examples/native_table_elements/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/native_table_elements/use_table_hook.ts
+++ b/examples/native_table_elements/use_table_hook.ts
@@ -1,6 +1,6 @@
-import React from "react";
 import { TableWrapper } from "utils/table_wrapper";
 import { NativeTableElement } from "@canva/preview/design";
+import { useCallback, useEffect, useState } from "react";
 
 /**
  * The current state of a cell within a table.
@@ -70,21 +70,17 @@ export const useTable = (
    */
   toElement(): NativeTableElement;
 } => {
-  const [rowCount, setRowCount] = React.useState(initialState.rowCount);
-  const [columnCount, setColumnCount] = React.useState(
-    initialState.columnCount
-  );
-  const [cells, setCells] = React.useState<CellState[]>(
-    initialState.cells || []
-  );
-  const [error, setError] = React.useState<string | undefined>();
-  const [wrapper, setWrapper] = React.useState<TableWrapper>(
+  const [rowCount, setRowCount] = useState(initialState.rowCount);
+  const [columnCount, setColumnCount] = useState(initialState.columnCount);
+  const [cells, setCells] = useState<CellState[]>(initialState.cells || []);
+  const [error, setError] = useState<string | undefined>();
+  const [wrapper, setWrapper] = useState<TableWrapper>(
     TableWrapper.create(rowCount || 1, columnCount || 1)
   );
 
-  const toElement = React.useCallback(() => wrapper.toElement(), [wrapper]);
+  const toElement = useCallback(() => wrapper.toElement(), [wrapper]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setError(undefined);
     if (typeof rowCount !== "number" || typeof columnCount !== "number") {
       return;
@@ -100,7 +96,7 @@ export const useTable = (
     }
   }, [rowCount, columnCount]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setError(undefined);
     try {
       for (const cell of cells) {

--- a/examples/native_text_elements/app.tsx
+++ b/examples/native_text_elements/app.tsx
@@ -9,7 +9,7 @@ import {
   Title,
 } from "@canva/app-ui-kit";
 import { addNativeElement, FontWeight, TextAttributes } from "@canva/design";
-import React from "react";
+import { useState } from "react";
 import styles from "styles/components.css";
 
 type UIState = {
@@ -31,7 +31,7 @@ const initialState: UIState = {
 };
 
 export const App = () => {
-  const [state, setState] = React.useState<UIState>(initialState);
+  const [state, setState] = useState<UIState>(initialState);
 
   const { text, color, fontWeight, fontStyle, decoration, textAlign } = state;
   const disabled = text.trim().length < 1 || color.trim().length < 1;

--- a/examples/native_text_elements/index.tsx
+++ b/examples/native_text_elements/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/open_external_link/app.tsx
+++ b/examples/open_external_link/app.tsx
@@ -1,6 +1,5 @@
 import { Button, Link, Rows, Text, Title } from "@canva/app-ui-kit";
 import { requestOpenExternalUrl } from "@canva/platform";
-import React from "react";
 import styles from "styles/components.css";
 
 const DOCS_URL =

--- a/examples/open_external_link/index.tsx
+++ b/examples/open_external_link/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/page_addition/app.tsx
+++ b/examples/page_addition/app.tsx
@@ -7,7 +7,7 @@ import type {
 import { addPage, getDefaultPageDimensions } from "@canva/design";
 import { CanvaError } from "@canva/error";
 import weather from "assets/images/weather.png";
-import React from "react";
+import { useState, useEffect } from "react";
 import styles from "styles/components.css";
 import { upload } from "@canva/asset";
 
@@ -54,13 +54,13 @@ const embedElement: NativeEmbedElement = {
 };
 
 export const App = () => {
-  const [error, setError] = React.useState<string | undefined>();
-  const [isLoading, setIsLoading] = React.useState(false);
-  const [defaultPageDimensions, setDefaultPageDimensions] = React.useState<
+  const [error, setError] = useState<string | undefined>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [defaultPageDimensions, setDefaultPageDimensions] = useState<
     Dimensions | undefined
   >();
 
-  React.useEffect(() => {
+  useEffect(() => {
     getDefaultPageDimensions().then((dimensions) => {
       // Dimensions are undefined if the user is in an unbounded design (e.g. Whiteboard).
       if (!dimensions) {

--- a/examples/page_addition/index.tsx
+++ b/examples/page_addition/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/page_background/app.tsx
+++ b/examples/page_background/app.tsx
@@ -1,11 +1,11 @@
-import * as React from "react";
 import { upload } from "@canva/asset";
 import { Button, Rows, Text } from "@canva/app-ui-kit";
 import { setCurrentPageBackground } from "@canva/design";
 import styles from "styles/components.css";
+import { useState } from "react";
 
 export const App = () => {
-  const [loading, setLoading] = React.useState(false);
+  const [loading, setLoading] = useState(false);
 
   const setBackgroundToSolidColor = async () => {
     setLoading(true);

--- a/examples/page_background/index.tsx
+++ b/examples/page_background/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/positioning_elements/app.tsx
+++ b/examples/positioning_elements/app.tsx
@@ -17,7 +17,7 @@ import {
 import cat from "assets/images/cat.jpg";
 import dog from "assets/images/dog.jpg";
 import rabbit from "assets/images/rabbit.jpg";
-import React from "react";
+import { useCallback, useEffect, useState } from "react";
 import baseStyles from "styles/components.css";
 import { upload } from "@canva/asset";
 
@@ -84,7 +84,7 @@ const appElementClient = initAppElement<AppElementData>({
 });
 
 export const App = () => {
-  const [state, setState] = React.useState<UIState>(initialState);
+  const [state, setState] = useState<UIState>(initialState);
   const { imageId } = state;
   const disabled = !imageId || imageId.trim().length < 1;
 
@@ -156,7 +156,7 @@ export const App = () => {
     };
   });
 
-  const addOrUpdateAppImage = React.useCallback(async () => {
+  const addOrUpdateAppImage = useCallback(async () => {
     if (!images[state.imageId].imageRef) {
       // Upload local image
       const { ref } = await upload({
@@ -176,7 +176,7 @@ export const App = () => {
     );
   }, [state]);
 
-  const addNativeImage = React.useCallback(async () => {
+  const addNativeImage = useCallback(async () => {
     if (!images[state.imageId].imageRef) {
       // Upload local image
       const { ref } = await upload({
@@ -197,7 +197,7 @@ export const App = () => {
     });
   }, [state]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     appElementClient.registerOnElementChange((appElement) => {
       setState((prevState) => {
         return appElement

--- a/examples/positioning_elements/index.tsx
+++ b/examples/positioning_elements/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { AppUiProvider } from "@canva/app-ui-kit";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/examples/richtext_replacement/app.tsx
+++ b/examples/richtext_replacement/app.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
 import { Button, Rows, Text } from "@canva/app-ui-kit";
+import { useEffect, useState } from "react";
 import { selection, SelectionEvent } from "@canva/preview/design";
 import styles from "styles/components.css";
 

--- a/examples/richtext_replacement/index.tsx
+++ b/examples/richtext_replacement/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";
 import "@canva/app-ui-kit/styles.css";

--- a/examples/text_replacement/app.tsx
+++ b/examples/text_replacement/app.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button, Rows, Text } from "@canva/app-ui-kit";
 import { useSelection } from "utils/use_selection_hook";
 import styles from "styles/components.css";

--- a/examples/text_replacement/index.tsx
+++ b/examples/text_replacement/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";
 import "@canva/app-ui-kit/styles.css";

--- a/examples/video_replacement/app.tsx
+++ b/examples/video_replacement/app.tsx
@@ -1,11 +1,11 @@
-import React from "react";
 import { Button, Rows, Text } from "@canva/app-ui-kit";
+import { useState } from "react";
 import styles from "styles/components.css";
 import { upload } from "@canva/asset";
 import { useSelection } from "utils/use_selection_hook";
 
 export const App = () => {
-  const [loading, setLoading] = React.useState(false);
+  const [loading, setLoading] = useState(false);
   const selection = useSelection("video");
 
   const updateVideo = async () => {

--- a/examples/video_replacement/index.tsx
+++ b/examples/video_replacement/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";
 import "@canva/app-ui-kit/styles.css";

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testRegex: '(/tests/.*|(\\.|/)(tests))\\.ts?$',
-  modulePathIgnorePatterns: ['./internal/', './node_modules/'],
+  testRegex: '(/tests/.*|(\\.|/)(tests))\\.tsx?$',
+  modulePathIgnorePatterns: ['./internal/'],
+  testPathIgnorePatterns: [ '/node_modules/', '/dist/']
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,18 @@
       "name": "canva-apps-sdk-starter-kit",
       "license": "SEE LICENSE IN LICENSE.md",
       "workspaces": [
-        "examples/*"
+        "./examples/*"
       ],
       "dependencies": {
-        "@canva/app-ui-kit": "^3.5.1",
+        "@canva/app-ui-kit": "^3.6.0",
         "@canva/asset": "^1.6.0",
         "@canva/design": "^1.9.0",
         "@canva/error": "^1.1.0",
         "@canva/platform": "^1.1.0",
         "@canva/preview": "./sdk/preview",
         "@canva/user": "^1.0.0",
-        "react": "^18.1.0",
-        "react-dom": "^18.1.0"
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@ngrok/ngrok": "^1.1.0",
@@ -32,7 +32,8 @@
         "@types/node-forge": "^1.3.1",
         "@types/nodemon": "^1.19.2",
         "@types/prompts": "^2.4.2",
-        "@types/react-dom": "^18.1.0",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
         "@types/webpack-env": "^1.18.0",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.2",
@@ -83,14 +84,6 @@
         "clsx": "^2.1.0"
       }
     },
-    "examples/app_image_elements/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "examples/app_shape_elements": {
       "license": "Please refer to the LICENSE.md file in the root directory"
     },
@@ -136,162 +129,6 @@
       },
       "devDependencies": {
         "@types/cors": "^2.8.17"
-      }
-    },
-    "examples/design_token/node_modules/array-flatten": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-    },
-    "examples/design_token/node_modules/body-parser": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.0.0-beta.2.tgz",
-      "integrity": "sha512-oxdqeGYQcO5ovwwkC1A89R0Mf0v3+7smTVh0chGfzDeiK37bg5bYNtXDy3Nmzn6CShoIYk5+nHTyBoSZIWwnCA==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "3.1.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.5.2",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "3.0.0-beta.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "examples/design_token/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "examples/design_token/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "examples/design_token/node_modules/express": {
-      "version": "5.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.0.0-beta.2.tgz",
-      "integrity": "sha512-qb6eRKeXBBzz0j1eiXnjkNvTo9sEbzEVhX712Nj0WfYlGUAkyYydhhw44aQto6ribVT4drRhHxKneQCzxYy+ow==",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "3.0.0",
-        "body-parser": "2.0.0-beta.2",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.6.0",
-        "cookie-signature": "1.0.6",
-        "debug": "3.1.0",
-        "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "mime-types": "~2.1.34",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "path-is-absolute": "1.0.1",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
-        "range-parser": "~1.2.1",
-        "router": "2.0.0-beta.2",
-        "safe-buffer": "5.2.1",
-        "send": "1.0.0-beta.2",
-        "serve-static": "2.0.0-beta.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "examples/design_token/node_modules/iconv-lite": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-      "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "examples/design_token/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "examples/design_token/node_modules/raw-body": {
-      "version": "3.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0-beta.1.tgz",
-      "integrity": "sha512-XlSTHr67bCjSo5aOfAnN3x507zGvi3unF65BW57limYkc2ws/XB0mLUtJvvP7JGFeSPsYrlCv1ZrPGh0cwDxPQ==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.5.2",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "examples/design_token/node_modules/send": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.0.0-beta.2.tgz",
-      "integrity": "sha512-k1yHu/FNK745PULKdsGpQ+bVSXYNwSk+bWnYzbxGZbt5obZc0JKDVANsCRuJD1X/EG15JtP9eZpwxkhUxIYEcg==",
-      "dependencies": {
-        "debug": "3.1.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime-types": "~2.1.34",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "examples/design_token/node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "examples/design_token/node_modules/serve-static": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.0.0-beta.2.tgz",
-      "integrity": "sha512-Ge718g4UJjzYoXFEGLY/VLSuTHp0kQcUV65QA98J8d3XREsVIHu53GBh9NWjDy4u2xwsSwRzu9nu7Q+b4o6Xyw==",
-      "dependencies": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "^1.0.0-beta.2"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "examples/digital_asset_management": {
@@ -366,14 +203,6 @@
         "clsx": "^2.1.0"
       }
     },
-    "examples/native_image_elements/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "examples/native_shape_elements": {
       "license": "Please refer to the LICENSE.md file in the root directory"
     },
@@ -396,14 +225,6 @@
       "license": "Please refer to the LICENSE.md file in the root directory",
       "dependencies": {
         "clsx": "^2.1.0"
-      }
-    },
-    "examples/positioning_elements/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "examples/richtext_replacement": {
@@ -2434,25 +2255,17 @@
         "react-dom": "^18.1.0"
       }
     },
-    "node_modules/@canva/app-components/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@canva/app-ui-kit": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@canva/app-ui-kit/-/app-ui-kit-3.5.1.tgz",
-      "integrity": "sha512-01/xTMOLyUBkex0auG+HX2iL64o3AC2Iy8aW2sJmFb2bUX6WUM3EKW0+Y2fn5+5pXdrrJ7DSOKNFUADNDphrIQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@canva/app-ui-kit/-/app-ui-kit-3.6.0.tgz",
+      "integrity": "sha512-ZRK4HCf3/DbG9H6x+QeUHCKfLb06kG4eKZbR7PMJnSqhymoeIrhlC8CtKMbYt1NkGGoOBaOaKzv0lr/h8gC45A==",
       "dependencies": {
         "@seznam/compose-react-refs": "^1.0.4",
         "classnames": "^2.2.5",
         "intl-messageformat": "^10.5.4",
         "intl-pluralrules": "^2.0.1",
         "make-plural": "^7.3.0",
-        "mobx": "6.12.3",
+        "mobx": "6.12.4",
         "mobx-react": "^7.5.2",
         "mobx-utils": "^6.0.5",
         "normalize-scroll-left": "^0.2.1",
@@ -2467,8 +2280,8 @@
         "tslib": "^2.5.0"
       },
       "peerDependencies": {
-        "react": "^18.1.0",
-        "react-dom": "^18.1.0"
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       }
     },
     "node_modules/@canva/asset": {
@@ -2554,9 +2367,9 @@
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
-      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.0.0.tgz",
+      "integrity": "sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==",
       "dependencies": {
         "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
@@ -2571,21 +2384,21 @@
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.6.tgz",
-      "integrity": "sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.8.tgz",
+      "integrity": "sha512-nBZJYmhpcSX0WeJ5SDYUkZ42AgR3xiyhNCsQweFx3cz/ULJjym8bHAzWKvG5e2+1XO98dBYC0fWeeAECAVSwLA==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
-        "@formatjs/icu-skeleton-parser": "1.8.0",
+        "@formatjs/ecma402-abstract": "2.0.0",
+        "@formatjs/icu-skeleton-parser": "1.8.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.0.tgz",
-      "integrity": "sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.2.tgz",
+      "integrity": "sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/ecma402-abstract": "2.0.0",
         "tslib": "^2.4.0"
       }
     },
@@ -4211,19 +4024,18 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.65",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.65.tgz",
-      "integrity": "sha512-98TsY0aW4jqx/3RqsUXwMDZSWR1Z4CUlJNue8ueS2/wcxZOsz4xmW1X8ieaWVRHcmmQM3R8xVA4XWB3dJnWwDQ==",
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
+      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.21",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.21.tgz",
-      "integrity": "sha512-gnvBA/21SA4xxqNXEwNiVcP0xSGHh/gi1VhWv9Bl46a0ItbTT5nFY+G9VSQpaG/8N/qdJpJ+vftQ4zflTtnjLw==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "devOptional": true,
       "dependencies": {
         "@types/react": "*"
@@ -4243,11 +4055,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -5016,12 +4823,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -5298,6 +5105,14 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
       }
@@ -6542,9 +6357,9 @@
       "link": true
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -7135,13 +6950,13 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.5.11",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.11.tgz",
-      "integrity": "sha512-eYq5fkFBVxc7GIFDzpFQkDOZgNayNTQn4Oufe8jw6YY6OHVw70/4pA3FyCsQ0Gb2DnvEJEMmN2tOaXUGByM+kg==",
+      "version": "10.5.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.14.tgz",
+      "integrity": "sha512-IjC6sI0X7YRjjyVH9aUgdftcmZK7WXdHeil4KwbjDnRWjnVitKpAx3rr6t6di1joFp5188VqKcobOPA6mCLG/w==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/ecma402-abstract": "2.0.0",
         "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.7.6",
+        "@formatjs/icu-messageformat-parser": "2.7.8",
         "tslib": "^2.4.0"
       }
     },
@@ -7282,11 +7097,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -8468,9 +8278,9 @@
       "dev": true
     },
     "node_modules/make-plural": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.3.0.tgz",
-      "integrity": "sha512-/K3BC0KIsO+WK2i94LkMPv3wslMrazrQhfi5We9fMbLlLjzoOSJWr7TAdupLlDWaJcWxwoNosBkhFDejiu5VDw=="
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.4.0.tgz",
+      "integrity": "sha512-4/gC9KVNTV6pvYg2gFeQYTW3mWaoJt7WZE5vrp1KnQDgW92JtYZnzmZT81oj/dUTqAIu0ufI2x3dkgu3bB1tYg=="
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -8630,9 +8440,9 @@
       }
     },
     "node_modules/mobx": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.12.3.tgz",
-      "integrity": "sha512-c8NKkO4R2lShkSXZ2Ongj1ycjugjzFFo/UswHBnS62y07DMcTc9Rvo03/3nRyszIvwPNljlkd4S828zIBv/piw==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.12.4.tgz",
+      "integrity": "sha512-uIymg89x+HmItX1p3MG+d09irn2k63J6biftZ5Ok+UpNojS1I3NJPLfcmJT9ANnUltNlHi+HQqrVyxiAN8ISYg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -9176,6 +8986,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9999,9 +9810,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10034,15 +9845,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-infinite-scroller": {
@@ -10351,33 +10162,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/router": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.0.0-beta.2.tgz",
-      "integrity": "sha512-ascmzrv4IAB64SpWzFwYOA+jz6PaUbrzHLPsQrPjQ3uQTL2qlhwY9S2sRvvBMgUISQptQG457jcWWcWqtwrbag==",
-      "dependencies": {
-        "array-flatten": "3.0.0",
-        "is-promise": "4.0.0",
-        "methods": "~1.1.2",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "3.2.0",
-        "setprototypeof": "1.2.0",
-        "utils-merge": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/router/node_modules/array-flatten": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
-      "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA=="
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -10403,9 +10187,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -12118,9 +11902,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -20,18 +20,18 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": true,
   "workspaces": [
-    "examples/*"
+    "./examples/*"
   ],
   "dependencies": {
-    "@canva/app-ui-kit": "^3.5.1",
+    "@canva/app-ui-kit": "^3.6.0",
     "@canva/asset": "^1.6.0",
     "@canva/design": "^1.9.0",
     "@canva/error": "^1.1.0",
     "@canva/platform": "^1.1.0",
     "@canva/preview": "./sdk/preview",
     "@canva/user": "^1.0.0",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@ngrok/ngrok": "^1.1.0",
@@ -45,7 +45,8 @@
     "@types/node-forge": "^1.3.1",
     "@types/nodemon": "^1.19.2",
     "@types/prompts": "^2.4.2",
-    "@types/react-dom": "^18.1.0",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
     "@types/webpack-env": "^1.18.0",
     "chalk": "^4.1.2",
     "cli-table3": "^0.6.2",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,5 @@
 import { Button, Rows, Text } from "@canva/app-ui-kit";
 import { addNativeElement } from "@canva/design";
-import * as React from "react";
 import styles from "styles/components.css";
 
 export const App = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
 import { AppUiProvider } from "@canva/app-ui-kit";
-import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";
 import "@canva/app-ui-kit/styles.css";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "lib": [
       "dom",
       "dom.iterable",

--- a/utils/backend/jwt_middleware/tests/jwt_middleware.tests.ts
+++ b/utils/backend/jwt_middleware/tests/jwt_middleware.tests.ts
@@ -195,7 +195,7 @@ describe("createJwtMiddleware", () => {
         getSigningKey.mockRejectedValue(new FakeSigningKeyNotFoundError());
       });
 
-      it(`Does not call next() and returns HTTP 401 with error = "unauthorized" and message = "Public key not found"`, async () => {
+      it(`Does not call next() and returns HTTP 401 with error = "unauthorized"`, async () => {
         expect.assertions(5);
 
         await jwtMiddleware(req, res, next);
@@ -204,10 +204,11 @@ describe("createJwtMiddleware", () => {
         expect(res.status).toHaveBeenLastCalledWith(401);
 
         expect(res.json).toHaveBeenCalledTimes(1);
-        expect(res.json).toHaveBeenLastCalledWith({
-          error: "unauthorized",
-          message: "Public key not found",
-        });
+        expect(res.json).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            error: "unauthorized",
+          })
+        );
 
         expect(next).not.toHaveBeenCalled();
       });

--- a/utils/use_overlay_hook.ts
+++ b/utils/use_overlay_hook.ts
@@ -5,7 +5,7 @@ import {
   overlay as designOverlay,
 } from "@canva/design";
 import { CloseParams, appProcess } from "@canva/platform";
-import React from "react";
+import { useEffect, useState } from "react";
 
 const initialOverlayEvent: OverlayOpenableEvent<OverlayTarget> = {
   canOpen: false,
@@ -34,18 +34,18 @@ export function useOverlay<
   close: (opts: C) => Promise<void>;
 } {
   const [overlay, setOverlay] =
-    React.useState<OverlayOpenableEvent<T>>(initialOverlayEvent);
-  const [overlayId, setOverlayId] = React.useState<AppProcessId>();
-  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+    useState<OverlayOpenableEvent<T>>(initialOverlayEvent);
+  const [overlayId, setOverlayId] = useState<AppProcessId>();
+  const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     return designOverlay.registerOnCanOpen({
       target,
       onCanOpen: setOverlay,
     });
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (overlayId) {
       appProcess.registerOnStateChange(overlayId, ({ state }) =>
         setIsOpen(state === "open")

--- a/utils/use_selection_hook.ts
+++ b/utils/use_selection_hook.ts
@@ -1,6 +1,6 @@
 import { selection as designSelection } from "@canva/design";
 import { SelectionEvent, SelectionScope } from "@canva/design";
-import React from "react";
+import { useEffect, useState } from "react";
 
 /**
  * Returns a selection event, representing a user selection of the specified content type. The
@@ -12,7 +12,7 @@ import React from "react";
 export function useSelection<S extends SelectionScope>(
   scope: S
 ): SelectionEvent<S> {
-  const [selection, setSelection] = React.useState<SelectionEvent<S>>({
+  const [selection, setSelection] = useState<SelectionEvent<S>>({
     scope,
     count: 0,
     read() {
@@ -25,7 +25,7 @@ export function useSelection<S extends SelectionScope>(
     },
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     const disposer = designSelection.registerOnChange({
       scope,
       onChange: setSelection,


### PR DESCRIPTION
## 2024-07-03

### 🧰 Added
- An `npm run test` step in `ci.yml`.

### 🐞 Fixed
- Fix of date test in `utils/backend/jwt_middleware`.
- Updated some dependencies by running `npm audit fix`.

### 🔧 Changed
- `@canva/app-ui-kit` 
  - Upgraded `app-ui-kit` to version `3.6.0`. Please see the [changelog](https://www.canva.dev/docs/apps/app-ui-kit/changelog/) for the list of changes.
- Upgraded `react`, `react-dom` and their type packages to version `18.3.1`.
- Removed unnecessary react imports by switching to `jsx-react`