### PR TITLE
Bump `@canva/asset` to version `1.7.0`, update colors example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `@canva/asset`
   - Upgraded to version `1.7.0` which has the following changes:
     - Added [asset.openColorSelector](https://www.canva.dev/docs/apps/using-color-selectors) which was previously in beta.
-    - Added selectedColor prop to [asset.openColorSelector](https://www.canva.dev/docs/apps/using-color-selectors)
+    - Added selectedColor prop to [asset.openColorSelector](https://www.canva.dev/docs/apps/using-color-selectors/#optional-step-5-handle-multiple-colors)
 
 - `@canva/preview/asset`
   - Added selectedColor prop to [asset.openColorSelector](https://www.canva.dev/docs/apps/using-color-selectors)
@@ -16,6 +16,7 @@
 
 - `@canva/preview/asset`
   - Updated [asset.openColorSelector](https://www.canva.dev/docs/apps/using-color-selectors) and some related types to be public.
+- Updated color example to use `@canva/asset` instead of `@canva/preview/asset`
 
 ## 2024-07-18
 

--- a/examples/color/app.tsx
+++ b/examples/color/app.tsx
@@ -3,8 +3,8 @@ import type {
   Anchor,
   ColorSelectionEvent,
   ColorSelectionScope,
-} from "@canva/preview/asset";
-import { openColorSelector } from "@canva/preview/asset";
+} from "@canva/asset";
+import { openColorSelector } from "@canva/asset";
 import { useState } from "react";
 import styles from "styles/components.css";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "dependencies": {
         "@canva/app-ui-kit": "^3.6.0",
-        "@canva/asset": "^1.6.0",
+        "@canva/asset": "^1.7.0",
         "@canva/design": "^1.9.0",
         "@canva/error": "^1.1.0",
         "@canva/platform": "^1.1.0",
@@ -2295,9 +2295,9 @@
       }
     },
     "node_modules/@canva/asset": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@canva/asset/-/asset-1.6.0.tgz",
-      "integrity": "sha512-u4pqVwsOap8utIhqHaxtCeDK4BKYBtoo6MpxfpTKCrhx4EIUnQeMPifmcB7Zi+nynJVWxkKwuxyXrDQRfe9o1A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@canva/asset/-/asset-1.7.0.tgz",
+      "integrity": "sha512-YIizmzYTcp9CeJfM5FHh0RNa7Du83y7GKo+0Hsk9p7XLtfuqPrfbm3iJ9s+oEIvyjlhwkInC+Bx+VjTQ9rogDQ==",
       "peerDependencies": {
         "@canva/error": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@canva/app-ui-kit": "^3.6.0",
-    "@canva/asset": "^1.6.0",
+    "@canva/asset": "^1.7.0",
     "@canva/design": "^1.9.0",
     "@canva/error": "^1.1.0",
     "@canva/platform": "^1.1.0",


### PR DESCRIPTION
### 🧰 Added
- `@canva/asset`
  - Upgraded to version `1.7.0` which has the following changes:
    - Added [asset.openColorSelector](https://www.canva.dev/docs/apps/using-color-selectors) which was previously in beta.
    - Added selectedColor prop to [asset.openColorSelector](https://www.canva.dev/docs/apps/using-color-selectors/#optional-step-5-handle-multiple-colors)

- `@canva/preview/asset`
  - Added selectedColor prop to [asset.openColorSelector](https://www.canva.dev/docs/apps/using-color-selectors)
### 🔧 Changed

- `@canva/preview/asset`
  - Updated [asset.openColorSelector](https://www.canva.dev/docs/apps/using-color-selectors) and some related types to be public.
- Updated color example to use `@canva/asset` instead of `@canva/preview/asset`