### PR TITLE
Bump `@canva/app-ui-kit` to version `4.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2024-10-30
+
+### 🔧 Changed
+
+- `@canva/app-ui-kit`
+  - Upgraded `app-ui-kit` to version `4.2.0`. Please see the [changelog](https://www.canva.dev/docs/apps/app-ui-kit/changelog/) for the list of changes.
+
 ## 2024-10-22
 
 ### 🧰 Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "dependencies": {
         "@canva/app-i18n-kit": "^1.0.0",
-        "@canva/app-ui-kit": "^4.1.0",
+        "@canva/app-ui-kit": "^4.2.0",
         "@canva/asset": "^2.0.0",
         "@canva/design": "^2.1.0",
         "@canva/error": "^2.0.0",
@@ -2210,10 +2210,9 @@
       }
     },
     "node_modules/@canva/app-ui-kit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@canva/app-ui-kit/-/app-ui-kit-4.1.0.tgz",
-      "integrity": "sha512-rPhX3mZtekPEvSECbl7ORtqYE0vume4HZGuPjBKVVY7Xp0PWbPLhnMp3f8nqUaNU+AFAY6iyRb+5C4ADlS6kJg==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@canva/app-ui-kit/-/app-ui-kit-4.2.0.tgz",
+      "integrity": "sha512-2u30yHlrntKUXCWJI45VaDCT5n3g+bggP+K1gIdnSWvOQ8sAHzTQ+0trxt0o5GGY0aWoJ5m4LD83AC45xdKQmA==",
       "dependencies": {
         "@floating-ui/react": "^0.26.16",
         "@seznam/compose-react-refs": "^1.0.4",
@@ -2223,7 +2222,7 @@
         "make-plural": "^7.3.0",
         "mobx": "6.13.3",
         "mobx-react-lite": "^4.0.7",
-        "mobx-utils": "^6.0.8",
+        "mobx-utils": "^6.1.0",
         "normalize-scroll-left": "^0.2.1",
         "react-dnd": "^7.6.0",
         "react-dnd-html5-backend": "^7.6.0",
@@ -2235,6 +2234,7 @@
         "tslib": "^2.5.0"
       },
       "peerDependencies": {
+        "mobx": "^6.13.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       }
@@ -10952,8 +10952,9 @@
       }
     },
     "node_modules/mobx-utils": {
-      "version": "6.0.8",
-      "license": "MIT",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/mobx-utils/-/mobx-utils-6.1.0.tgz",
+      "integrity": "sha512-P3qUVDFp3Kv5HXD7EIGJn3zlgJJnN+/ZpFHWQ+u6YNN1xDxY53iMvsQ9fM8kauTVdDmt7ulDgDQtDrOxb1NS9Q==",
       "peerDependencies": {
         "mobx": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@canva/app-i18n-kit": "^1.0.0",
-    "@canva/app-ui-kit": "^4.1.0",
+    "@canva/app-ui-kit": "^4.2.0",
     "@canva/asset": "^2.0.0",
     "@canva/design": "^2.1.0",
     "@canva/error": "^2.0.0",


### PR DESCRIPTION
## 2024-10-30

### 🔧 Changed

- `@canva/app-ui-kit`
  - Upgraded `app-ui-kit` to version `4.2.0`. Please see the [changelog](https://www.canva.dev/docs/apps/app-ui-kit/changelog/) for the list of changes.