### PR TITLE
Design Editing API is out of preview! Introducing the Notification API! Adding the getDesignMetaData method in preview!

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "canva": {
+      "command": "npx",
+      "args": ["-y", "@canva/cli@latest", "mcp"]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 2025-06-26
+
+### 🧰 Added
+
+- `@canva/design`
+  - `openDesign`:
+    - `helpers`: New async helper methods `group` and `ungroup`. See the documentation on [PageHelpers](https://www.canva.dev/docs/apps/api/latest/design-types-page-helpers/) for more information.
+- `@canva/design@beta`
+  - Added the [`getDesignMetadata`](https://www.canva.dev/docs/apps/api/preview/design-get-design-metadata/) method, which allows apps to get information about the design.
+- `@canva/platform` updated to version `2.2.0`.
+  - Added the `notification.addToast`: [Notification API](https://www.canva.dev/docs/apps/api/latest/platform-notification-add-toast/) which allows apps to display lightweight toast messages in the Canva editor.
+- `examples`
+  - Added `examples/notification` as a basic implementation of the new `@canva/platform` [`notification.addToast()`](https://www.canva.dev/docs/apps/api/latest/platform-notification-add-toast/) API.
+  - Added `examples/design_metadata` as a basic implementation to demonstrate the new [`getDesignMetadata`](https://www.canva.dev/docs/apps/api/preview/design-get-design-metadata/) method.
+
+### 🔧 Changed
+
+- Upgraded `webpack-dev-server` to version `5.2.2` from `5.2.0` and adjusted the webpack configuration to work with the new version.
+- `@canva/design` updated to version `2.6.0`.
+  - `openDesign`: [Design Editing API](https://www.canva.dev/docs/apps/api/latest/design-open-design/) is out of preview and Generally Available!
+    - `openDesign` function signature change:
+      - Before: `openDesign({ type: 'current_page' }, (draft: { page, save }, helpers) => {})`.
+      - After: `openDesign({ type: 'current_page' }, (session: { page, sync, helpers }) => {})`.
+        - `save` is superseded by `sync`. Unlike `save`, `sync` can be called multiple times as needed.
+    - `page`:
+      - Renamed page type: `fixed` → `absolute`.
+      - New page type: `unsupported`, which represents pages that are not `absolute` (previously `fixed`).
+    - `helpers`:
+      - Renamed `elementBuilder` to `elementStateBuilder`.
+        - `cloneElement` was removed as part of the refactor.
+    - Fills:
+      - `media` and `color` are superseded by `mediaContainer` and `colorContainer`.
+        - Read: `xxxContainer.ref`.
+        - Write: `xxxContainer.set(...)`.
+      - For shape path fills, `isMediaEditable` introduced to indicate editability.
+- `examples`:
+  - Updated `examples/authentication` to better align with the API spec.
+  - Updated `examples/design_editing` to reflect the latest `@canva/design` changes.
+
 ## 2025-06-12
 
 ### 🧰 Added

--- a/examples/data_connector_intent/selection_ui.tsx
+++ b/examples/data_connector_intent/selection_ui.tsx
@@ -92,7 +92,7 @@ export const SelectionUI = (request: RenderSelectionUiRequest) => {
           <Alert tone="positive" title="Data preview loaded successfully!" />
         )}
         <Text variant="bold">
-          Total construction project sales in each release stage
+          Sydney construction project sales in each release stage
         </Text>
         <Rows spacing="1u">
           <FormField

--- a/examples/design_editing/app.tsx
+++ b/examples/design_editing/app.tsx
@@ -4,7 +4,7 @@
  * then upload them to Canva using the `upload` function from the `@canva/asset` package.
  */
 /* eslint-disable no-restricted-imports */
-import { Button, Rows, Text } from "@canva/app-ui-kit";
+import { Button, Rows, Text, Alert } from "@canva/app-ui-kit";
 import { upload } from "@canva/asset";
 import type { DesignEditing } from "@canva/design";
 import { openDesign } from "@canva/design";
@@ -19,13 +19,36 @@ enum Operation {
   FLIP,
   DELETE,
   INSERT,
+  GROUP,
+  INSERT_AND_GROUP,
 }
 
 export const App = () => {
   const [operation, setOperation] = useState<Operation>(Operation.NONE);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  // This is a helper function to check that the page we retrieved is
+  // an "Absolute" page. Other pages are not supported by the API.
+  function checkAbsolute(
+    page: DesignEditing.Page,
+  ): asserts page is DesignEditing.AbsolutePage {
+    if (page.type !== "absolute") {
+      setError("Page type is not supported");
+      throw new Error("Page type is not supported");
+    } else {
+      setError(undefined);
+    }
+  }
+
+  // This method shows how to replace all fills on the page
+  // with an image
   const replaceAllFillsWithDogs = () => {
-    openDesign({ type: "current_page" }, async (draft) => {
-      const elementsToReplace = draft.page.elements.filter(
+    openDesign({ type: "current_page" }, async (session) => {
+      // Check that we're on a supported page
+      checkAbsolute(session.page);
+
+      // Find all elements on the page that can contain a fill
+      const elementsToReplace = session.page.elements.filter(
         (el) => el.type === "rect" || el.type === "shape",
       );
 
@@ -33,6 +56,9 @@ export const App = () => {
         return;
       }
 
+      setOperation(Operation.UPDATE);
+
+      // Upload the image we want to use
       const dogImage = await uploadLocalImage();
       const dogMedia: DesignEditing.ImageFill = {
         type: "image",
@@ -40,82 +66,118 @@ export const App = () => {
         flipY: false,
         imageRef: dogImage.ref,
       };
+
+      // For each element, update the fills to contain our new image
       elementsToReplace.forEach((element) => {
         switch (element.type) {
           case "rect":
-            element.fill.media = dogMedia;
+            element.fill.mediaContainer.set(dogMedia);
             break;
           case "shape":
-            element.paths.forEach((p) => (p.fill.media = dogMedia));
+            // Some shape paths cannot be edited, so we need to check for this
+            element.paths.forEach(
+              (p) =>
+                p.fill.isMediaEditable && p.fill.mediaContainer.set(dogMedia),
+            );
             break;
           default:
             throw new Error("Unexpected Element");
         }
       });
-
-      setOperation(Operation.UPDATE);
-      return draft.save().finally(() => setOperation(Operation.NONE));
-    });
+      // Save the changes
+      return session.sync();
+    })
+      .catch((e) => (e instanceof Error ? setError(e.message) : setError(e)))
+      .finally(() => setOperation(Operation.NONE));
   };
 
+  // This method flips the design around the Y-axis
   const flipDesign = () => {
-    openDesign({ type: "current_page" }, async (draft) => {
-      // Whiteboards do not have fixed dimensions, so we can use this to figure out
+    openDesign({ type: "current_page" }, async (session) => {
+      checkAbsolute(session.page);
+      // Whiteboards do not have static dimensions, so we can use this to figure out
       // the dimensions that bound the elements
-      const dimensions = findElementsBoundingBox(draft.page.elements);
+      const dimensions = findElementsBoundingBox(session.page.elements);
 
-      // For designs with fixed dimensions, the center is just half the width.
-      const pageCenter = draft.page.dimensions
-        ? draft.page.dimensions.width / 2
+      // For designs with static dimensions, the center is just half the width.
+      const pageCenter = session.page.dimensions
+        ? session.page.dimensions.width / 2
         : dimensions.centerX;
 
-      draft.page.elements.forEach((element) => {
-        // compute new x-position by flipping elements around the center
-        element.left = 2 * pageCenter - element.left - element.width;
-        // also horizontally flip any media
-        if (element.type === "rect" && element.fill.media != null) {
-          element.fill.media.flipX = !element.fill.media.flipX;
-        }
-        if (element.type === "shape") {
-          element.paths.forEach((path) => {
-            if (path.fill.media != null) {
-              path.fill.media.flipX = !path.fill.media.flipX;
-            }
-          });
-        }
-      });
+      session.page.elements
+        .filter((element) => element.type !== "unsupported")
+        .forEach((element) => {
+          // compute new x-position by flipping elements around the center
+          element.left = 2 * pageCenter - element.left - element.width;
+          // also horizontally flip any media
+          if (
+            element.type === "rect" &&
+            element.fill.mediaContainer.ref != null
+          ) {
+            element.fill.mediaContainer.ref.flipX =
+              !element.fill.mediaContainer.ref.flipX;
+          }
+          if (element.type === "shape") {
+            element.paths.forEach((path) => {
+              if (path.fill.mediaContainer.ref != null) {
+                path.fill.mediaContainer.ref.flipX =
+                  !path.fill.mediaContainer.ref.flipX;
+              }
+            });
+          }
+        });
 
       setOperation(Operation.FLIP);
-      return draft.save().finally(() => setOperation(Operation.NONE));
-    });
+      // Save the changes to the design
+      return session.sync();
+    })
+      .catch((e) => (e instanceof Error ? setError(e.message) : setError(e)))
+      .finally(() => setOperation(Operation.NONE));
   };
 
+  // This shows an example of how to delete elements
   const deleteAllTextElements = () => {
-    openDesign({ type: "current_page" }, async (draft) => {
-      draft.page.elements.forEach((element) => {
+    openDesign({ type: "current_page" }, async (session) => {
+      // Check that we're on a supported page
+      checkAbsolute(session.page);
+      const page = session.page;
+      // Delete all text elements
+      page.elements.forEach((element) => {
         if (element.type === "text") {
-          draft.page.elements.delete(element);
+          page.elements.delete(element);
         }
       });
 
       setOperation(Operation.DELETE);
-      return draft.save().finally(() => setOperation(Operation.NONE));
-    });
+      // Save the changes to the design
+      return session.sync();
+    })
+      .catch((e) => (e instanceof Error ? setError(e.message) : setError(e)))
+      .finally(() => setOperation(Operation.NONE));
   };
 
+  // This examples shows how you can add elements to the design
   const addTextWithSparkles = () => {
-    openDesign({ type: "current_page" }, async (draft, { elementBuilder }) => {
+    setOperation(Operation.INSERT);
+    openDesign({ type: "current_page" }, async (session) => {
+      // Check that we're on a supported page
+      checkAbsolute(session.page);
+      // The elementStateBuilder provides convenience methods for creating new elements
+      const { elementStateBuilder } = session.helpers;
       const { ref } = await uploadSparkle();
-      const text = elementBuilder.createRichtextRange();
+      const text = elementStateBuilder.createRichtextRange();
       text.appendText("Hello World");
       text.formatParagraph({ index: 0, length: 11 }, { fontSize: 60 });
+
       // Add text element to design
-      const insertedText = draft.page.elements.insertBefore(
+      // Note that the only way to add elements to a design is to insert
+      // the element into a page's elements list
+      const insertedText = session.page.elements.insertBefore(
         undefined,
-        elementBuilder.createTextElement({
-          text,
-          left: (draft.page.dimensions?.width || 0) / 2 - 160,
-          top: (draft.page.dimensions?.height || 0) / 2 - 160,
+        elementStateBuilder.createTextElement({
+          text: { regions: text.readTextRegions() },
+          left: (session.page.dimensions?.width || 0) / 2 - 160,
+          top: (session.page.dimensions?.height || 0) / 2 - 160,
           width: 320,
         }),
       );
@@ -125,15 +187,15 @@ export const App = () => {
       }
 
       // Insert a sparkle behind the text
-      draft.page.elements.insertBefore(
+      session.page.elements.insertBefore(
         insertedText,
-        elementBuilder.createRectElement({
+        elementStateBuilder.createRectElement({
           left: insertedText.left - 25,
           top: insertedText.top - 10,
           width: 50,
           height: 50,
           fill: {
-            media: {
+            mediaContainer: {
               imageRef: ref,
               type: "image",
             },
@@ -142,15 +204,15 @@ export const App = () => {
       );
 
       // Insert a sparkle in front of the text
-      draft.page.elements.insertAfter(
+      session.page.elements.insertAfter(
         insertedText,
-        elementBuilder.createRectElement({
+        elementStateBuilder.createRectElement({
           left: insertedText.left + 280,
           top: insertedText.top + 20,
           width: 50,
           height: 50,
           fill: {
-            media: {
+            mediaContainer: {
               imageRef: ref,
               type: "image",
             },
@@ -158,16 +220,123 @@ export const App = () => {
         }),
       );
 
-      // Save the changes
-      setOperation(Operation.INSERT);
-      return draft.save().finally(() => setOperation(Operation.NONE));
-    });
+      // Save the changes to the design
+      return session.sync();
+    })
+      .catch((e) => (e instanceof Error ? setError(e.message) : setError(e)))
+      .finally(() => setOperation(Operation.NONE));
   };
+
+  // This example shows how to use a helper to group elements
+  async function groupAllSupportedElements() {
+    return openDesign({ type: "current_page" }, async (session) => {
+      // Check that we're on a supported page
+      checkAbsolute(session.page);
+      const { group } = session.helpers;
+
+      // get all elements on the page that can be grouped
+      const elsToGroup = session.page.elements.filter(
+        (el) =>
+          el.type === "embed" ||
+          el.type === "rect" ||
+          el.type === "shape" ||
+          el.type === "text",
+      );
+      if (elsToGroup.length < 2) {
+        setError(
+          "Need at least 2 supported elements (embed, rect, shape or text) to group them",
+        );
+        return;
+      }
+      setOperation(Operation.GROUP);
+      // Group the elements
+      await group({ elements: elsToGroup });
+      // Save the changes to the design
+      await session.sync();
+    })
+      .catch((e) => (e instanceof Error ? setError(e.message) : setError(e)))
+      .finally(() => setOperation(Operation.NONE));
+  }
+
+  // This shows an example of how to add a group to a page
+  async function insertAndGroup() {
+    return openDesign({ type: "current_page" }, async (session) => {
+      // Check that we're on a supported page
+      checkAbsolute(session.page);
+      const { group, elementStateBuilder } = session.helpers;
+      const width = session.page.dimensions?.width || 0;
+      const height = session.page.dimensions?.height || 0;
+
+      // Create the elements we want in the group
+      const shape = session.page.elements.insertBefore(
+        undefined,
+        elementStateBuilder.createShapeElement({
+          top: (height ? height / 2 : 0) - 300,
+          left: (width ? width / 2 : 0) - 300,
+          width: 600,
+          height: 600,
+          viewBox: {
+            top: 0,
+            left: 0,
+            width: 64,
+            height: 64,
+          },
+          paths: [
+            {
+              d: "M32 0L36.5053 3.55458L41.8885 1.56619L45.0749 6.33901L50.8091 6.11146L52.3647 11.6353L57.8885 13.1909L57.661 18.9251L62.4338 22.1115L60.4454 27.4947L64 32L60.4454 36.5053L62.4338 41.8885L57.661 45.0749L57.8885 50.8091L52.3647 52.3647L50.8091 57.8885L45.0749 57.661L41.8885 62.4338L36.5053 60.4454L32 64L27.4947 60.4454L22.1115 62.4338L18.9251 57.661L13.1909 57.8885L11.6353 52.3647L6.11146 50.8091L6.33901 45.0749L1.56619 41.8885L3.55458 36.5053L0 32L3.55458 27.4947L1.56619 22.1115L6.33901 18.9251L6.11146 13.1909L11.6353 11.6353L13.1909 6.11146L18.9251 6.33901L22.1115 1.56619L27.4947 3.55458L32 0Z",
+              fill: {
+                colorContainer: {
+                  color: "#ffde59",
+                  type: "solid",
+                },
+              },
+            },
+          ],
+        }),
+      );
+
+      if (shape == null) {
+        setError("Could not create shape element");
+        return;
+      }
+
+      const textRange = elementStateBuilder.createRichtextRange();
+      textRange.appendText("Well Done!");
+      textRange.formatParagraph(
+        { index: 0, length: 11 },
+        { fontSize: 45, color: "#000000", textAlign: "center" },
+      );
+
+      const text = session.page.elements.insertAfter(
+        shape,
+        elementStateBuilder.createTextElement({
+          top: shape.top + shape.height / 2 - 30,
+          left: shape.left,
+          width: shape?.width,
+          text: { regions: textRange.readTextRegions() },
+        }),
+      );
+
+      if (text == null) {
+        setError("Could not create text element");
+        return;
+      }
+
+      setOperation(Operation.INSERT_AND_GROUP);
+      // Group the elements we created
+      await group({ elements: [shape, text] });
+      // Save the changes to the design
+      await session.sync();
+    })
+      .catch((e) => (e instanceof Error ? setError(e.message) : setError(e)))
+      .finally(() => setOperation(Operation.NONE));
+  }
 
   return (
     <div className={styles.scrollContainer}>
       <Rows spacing="2u">
         <Text>This example demonstrates how apps can edit the design</Text>
+        {error && <Alert tone="critical">{error}</Alert>}
         <Button
           variant="secondary"
           onClick={flipDesign}
@@ -200,6 +369,22 @@ export const App = () => {
         >
           Add some sparkly text
         </Button>
+        <Button
+          variant="secondary"
+          onClick={groupAllSupportedElements}
+          disabled={operation !== Operation.NONE}
+          loading={operation === Operation.GROUP}
+        >
+          Group elements on page
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={insertAndGroup}
+          disabled={operation !== Operation.NONE}
+          loading={operation === Operation.INSERT_AND_GROUP}
+        >
+          Insert a group of Elements
+        </Button>
       </Rows>
     </div>
   );
@@ -229,9 +414,7 @@ function uploadSparkle() {
   });
 }
 
-function findElementsBoundingBox(
-  elements: DesignEditing.List<DesignEditing.FixedElement>,
-) {
+function findElementsBoundingBox(elements: DesignEditing.ElementList) {
   const lefts: number[] = [];
   const tops: number[] = [];
   const rights: number[] = [];

--- a/examples/design_metadata/app.tsx
+++ b/examples/design_metadata/app.tsx
@@ -1,0 +1,46 @@
+import {
+  Button,
+  FormField,
+  MultilineInput,
+  Rows,
+  Text,
+} from "@canva/app-ui-kit";
+
+import type { DesignMetadata } from "@canva/design";
+import { getDesignMetadata } from "@canva/design";
+
+import * as styles from "styles/components.css";
+import React, { useState } from "react";
+
+export const App = () => {
+  const [designMetadata, setDesignMetadata] = useState<
+    DesignMetadata | undefined
+  >();
+
+  const getDesignInfo = React.useCallback(async () => {
+    const response = await getDesignMetadata();
+    setDesignMetadata(response);
+  }, [getDesignMetadata]);
+
+  return (
+    <div className={styles.scrollContainer}>
+      <Rows spacing="3u">
+        <Text>
+          This example demonstrates how apps can retrieve information about the
+          design.
+        </Text>
+        <Button variant="primary" onClick={getDesignInfo} stretch>
+          Get Design Metadata
+        </Button>
+
+        <FormField
+          label="Design Metadata"
+          value={JSON.stringify(designMetadata, null, 2)}
+          control={(props) => (
+            <MultilineInput {...props} maxRows={12} autoGrow readOnly />
+          )}
+        />
+      </Rows>
+    </div>
+  );
+};

--- a/examples/design_metadata/index.tsx
+++ b/examples/design_metadata/index.tsx
@@ -1,0 +1,19 @@
+import { AppUiProvider } from "@canva/app-ui-kit";
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+import "@canva/app-ui-kit/styles.css";
+
+const root = createRoot(document.getElementById("root") as Element);
+function render() {
+  root.render(
+    <AppUiProvider>
+      <App />
+    </AppUiProvider>,
+  );
+}
+
+render();
+
+if (module.hot) {
+  module.hot.accept("./app", render);
+}

--- a/examples/design_metadata/package.json
+++ b/examples/design_metadata/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "design_metadata",
+  "description": "An example app demonstrating how apps can retrieve information about the design",
+  "author": "Canva Pty Ltd.",
+  "license": "Please refer to the LICENSE.md file in the root directory",
+  "dependencies": {
+    "@canva/design": "^2.6.0-beta.1"
+  }
+}

--- a/examples/notification/app.tsx
+++ b/examples/notification/app.tsx
@@ -1,0 +1,31 @@
+import { Button, Rows, Text } from "@canva/app-ui-kit";
+import { notification } from "@canva/platform";
+import * as styles from "styles/components.css";
+
+export const App = () => {
+  const funMessages = [
+    "🚀 Keep going, superstar!",
+    "💪 You got this!",
+    "🌟 Shine bright!",
+    "🔥 Crushing it!",
+    "🏆 Winner vibes only!",
+  ];
+
+  const handleClick = () => {
+    const randomMessage =
+      funMessages[Math.floor(Math.random() * funMessages.length)];
+    notification.addToast({
+      messageText: randomMessage,
+    });
+  };
+  return (
+    <div className={styles.scrollContainer}>
+      <Rows spacing="1u">
+        <Text>Apps can trigger notifications:</Text>
+        <Button variant="primary" onClick={handleClick}>
+          Show a fun toast notification 🍞
+        </Button>
+      </Rows>
+    </div>
+  );
+};

--- a/examples/notification/index.tsx
+++ b/examples/notification/index.tsx
@@ -1,0 +1,19 @@
+import { AppUiProvider } from "@canva/app-ui-kit";
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+import "@canva/app-ui-kit/styles.css";
+
+const root = createRoot(document.getElementById("root") as Element);
+function render() {
+  root.render(
+    <AppUiProvider>
+      <App />
+    </AppUiProvider>,
+  );
+}
+
+render();
+
+if (module.hot) {
+  module.hot.accept("./app", render);
+}

--- a/examples/notification/package.json
+++ b/examples/notification/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "design_editing",
-  "description": "An example app that demonstrates how to edit the design.",
+  "name": "notification",
+  "description": "An example app that demonstrates how to show a notification.",
   "author": "Canva Pty Ltd.",
   "license": "Please refer to the LICENSE.md file in the root directory"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
         "@canva/app-i18n-kit": "^1.0.2",
         "@canva/app-ui-kit": "^4.9.0",
         "@canva/asset": "^2.2.0",
-        "@canva/design": "^2.4.1",
+        "@canva/design": "^2.6.0",
         "@canva/error": "^2.1.0",
         "@canva/intents": "^2.0.0",
-        "@canva/platform": "^2.1.0",
+        "@canva/platform": "^2.2.0",
         "@canva/user": "^2.1.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -79,7 +79,7 @@
         "url-loader": "4.1.1",
         "webpack": "5.97.1",
         "webpack-cli": "5.1.4",
-        "webpack-dev-server": "5.2.0",
+        "webpack-dev-server": "5.2.2",
         "yargs": "17.7.2"
       },
       "engines": {
@@ -92,6 +92,15 @@
       "version": "0.8.0",
       "extraneous": true,
       "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "@canva/error": "^2.0.0"
+      }
+    },
+    "../apps-sdk/published/preview/platform/pkg": {
+      "name": "@canva/platform",
+      "version": "2.2.0-beta.1",
+      "extraneous": true,
+      "license": "SEE LICENSE IN LICENSE.md FILE",
       "peerDependencies": {
         "@canva/error": "^2.0.0"
       }
@@ -136,14 +145,6 @@
         "@types/cors": "2.8.17"
       }
     },
-    "examples/beta_app_image_elements": {
-      "extraneous": true,
-      "license": "Please refer to the LICENSE.md file in the root directory",
-      "dependencies": {
-        "@canva/design": "^2.3.0-beta.1",
-        "clsx": "2.1.1"
-      }
-    },
     "examples/color": {
       "license": "Please refer to the LICENSE.md file in the root directory"
     },
@@ -155,15 +156,18 @@
       "license": "Please refer to the LICENSE.md file in the root directory"
     },
     "examples/design_editing": {
+      "license": "Please refer to the LICENSE.md file in the root directory"
+    },
+    "examples/design_metadata": {
       "license": "Please refer to the LICENSE.md file in the root directory",
       "dependencies": {
-        "@canva/design": "^2.4.1-beta.1"
+        "@canva/design": "^2.6.0-beta.1"
       }
     },
-    "examples/design_editing/node_modules/@canva/design": {
-      "version": "2.4.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@canva/design/-/design-2.4.1-beta.1.tgz",
-      "integrity": "sha512-tuKlrYp1C+r2W8BLzToiFN5vKvXbIC29xpJqE5nifZ/1D8xRTMlQ+8YnyrTgkUI/i1BRim97+mwkGMb4WlQ9dA==",
+    "examples/design_metadata/node_modules/@canva/design": {
+      "version": "2.6.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@canva/design/-/design-2.6.0-beta.1.tgz",
+      "integrity": "sha512-53X6tYLk1dSksNWMpr+Vd+AY5KKQJ6C4U0dVJTgnMaYHPubOagn7mbsWXYpt772tgpD/C3FStCNOZBlClVLxlw==",
       "license": "SEE LICENSE IN LICENSE.md FILE",
       "peerDependencies": {
         "@canva/error": "^2.0.0"
@@ -300,6 +304,9 @@
         "clsx": "^2.1.0"
       }
     },
+    "examples/notification": {
+      "license": "Please refer to the LICENSE.md file in the root directory"
+    },
     "examples/open_external_link": {
       "license": "Please refer to the LICENSE.md file in the root directory"
     },
@@ -331,7 +338,7 @@
       "extraneous": true,
       "license": "Please refer to the LICENSE.md file in the root directory",
       "dependencies": {
-        "@canva/design": "^2.4.1-beta.1",
+        "@canva/design": "^2.6.0-beta.1",
         "clsx": "2.1.1"
       }
     },
@@ -2247,9 +2254,9 @@
       }
     },
     "node_modules/@canva/design": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@canva/design/-/design-2.4.1.tgz",
-      "integrity": "sha512-jutVdwGnbnQZolFh5cKl498whcyNX+lfzynQQLKillnzzozBrMR53U8KGdIRaC5TWmYK/IqBAbatdXoZNEACmQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@canva/design/-/design-2.6.0.tgz",
+      "integrity": "sha512-bu2xt1AVGsREhpe6izDgRP+ht62ylg0F+jN+wIQWRwV6tUyRY31a6wrfA0beGEq/5Ntx+Bn1KHOHlHo5dCIkcw==",
       "license": "SEE LICENSE IN LICENSE.md FILE",
       "peerDependencies": {
         "@canva/error": "^2.0.0"
@@ -2271,10 +2278,9 @@
       }
     },
     "node_modules/@canva/platform": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@canva/platform/-/platform-2.1.0.tgz",
-      "integrity": "sha512-5IsQsMG1JJ8mOKEfKPcTdW/FZh2A4s4WbJH6dd09ZT1FlD8Mno1n3p7YgHwfZNNtfsZftZJ5L4mSaxHTxDjZhA==",
-      "license": "SEE LICENSE IN LICENSE.md FILE",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@canva/platform/-/platform-2.2.0.tgz",
+      "integrity": "sha512-9cPeMTnnVns9kl/PTaLobSjYv2LI1SkaZwmSLo9n2KsSNQzgWj/e6hnTaq76zjoOWcTLFu4eK8fmbrhVSJ+9oA==",
       "peerDependencies": {
         "@canva/error": "^2.0.0"
       }
@@ -4136,7 +4142,9 @@
       "license": "MIT"
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.15",
+      "version": "1.17.16",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6806,6 +6814,10 @@
       "resolved": "examples/design_editing",
       "link": true
     },
+    "node_modules/design_metadata": {
+      "resolved": "examples/design_metadata",
+      "link": true
+    },
     "node_modules/design_token": {
       "resolved": "examples/design_token",
       "link": true
@@ -7879,6 +7891,8 @@
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8271,7 +8285,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.8",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "dev": true,
       "funding": [
         {
@@ -8808,6 +8824,8 @@
     },
     "node_modules/http-proxy": {
       "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8833,9 +8851,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9613,6 +9631,8 @@
     },
     "node_modules/is-plain-obj": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11745,6 +11765,10 @@
       "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.1.tgz",
       "integrity": "sha512-YanMJCtsykxVQuWiwQR531bbyPtMt/jpUKy2XcVVe/oHiDgYme0NmuEZfceLeZhFbrQtO/GS/9KvWbSfDGRblA==",
       "license": "MIT"
+    },
+    "node_modules/notification": {
+      "resolved": "examples/notification",
+      "link": true
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -15608,15 +15632,16 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.0.tgz",
-      "integrity": "sha512-90SqqYXA2SK36KcT6o1bvwvZfJFcmoamqeJY7+boioffX9g9C0wjjJRGUrQIuh43pb0ttX7+ssavmj/WN2RHtA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+      "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
         "@types/express": "^4.17.21",
+        "@types/express-serve-static-core": "^4.17.21",
         "@types/serve-index": "^1.9.4",
         "@types/serve-static": "^1.15.5",
         "@types/sockjs": "^0.3.36",
@@ -15629,7 +15654,7 @@
         "connect-history-api-fallback": "^2.0.0",
         "express": "^4.21.2",
         "graceful-fs": "^4.2.6",
-        "http-proxy-middleware": "^2.0.7",
+        "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
         "launch-editor": "^2.6.1",
         "open": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "@canva/app-i18n-kit": "^1.0.2",
     "@canva/app-ui-kit": "^4.9.0",
     "@canva/asset": "^2.2.0",
-    "@canva/design": "^2.4.1",
+    "@canva/design": "^2.6.0",
     "@canva/error": "^2.1.0",
     "@canva/intents": "^2.0.0",
-    "@canva/platform": "^2.1.0",
+    "@canva/platform": "^2.2.0",
     "@canva/user": "^2.1.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
@@ -97,7 +97,7 @@
     "url-loader": "4.1.1",
     "webpack": "5.97.1",
     "webpack-cli": "5.1.4",
-    "webpack-dev-server": "5.2.0",
+    "webpack-dev-server": "5.2.2",
     "yargs": "17.7.2"
   }
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -191,6 +191,7 @@ function buildDevConfig(options?: DevConfig): {
 
   const { port, enableHmr, appOrigin, appId, enableHttps, certFile, keyFile } =
     options;
+  const host = "localhost";
 
   let devServer: DevServerConfiguration = {
     server: enableHttps
@@ -202,7 +203,8 @@ function buildDevConfig(options?: DevConfig): {
           },
         }
       : "http",
-    host: "localhost",
+    host,
+    allowedHosts: [host],
     historyApiFallback: {
       rewrites: [{ from: /^\/$/, to: "/app.js" }],
     },
@@ -219,7 +221,7 @@ function buildDevConfig(options?: DevConfig): {
   if (enableHmr && appOrigin) {
     devServer = {
       ...devServer,
-      allowedHosts: new URL(appOrigin).hostname,
+      allowedHosts: [host, new URL(appOrigin).hostname],
       headers: {
         "Access-Control-Allow-Origin": appOrigin,
         "Access-Control-Allow-Credentials": "true",
@@ -237,7 +239,7 @@ function buildDevConfig(options?: DevConfig): {
     const appDomain = `app-${appId.toLowerCase().trim()}.canva-apps.com`;
     devServer = {
       ...devServer,
-      allowedHosts: appDomain,
+      allowedHosts: [host, appDomain],
       headers: {
         "Access-Control-Allow-Origin": `https://${appDomain}`,
         "Access-Control-Allow-Credentials": "true",


### PR DESCRIPTION
## 2025-06-26

### 🧰 Added

- `@canva/design`
  - `openDesign`:
    - `helpers`: New async helper methods `group` and `ungroup`. See the documentation on [PageHelpers](https://www.canva.dev/docs/apps/api/latest/design-types-page-helpers/) for more information.
- `@canva/design@beta`
  - Added the [`getDesignMetadata`](https://www.canva.dev/docs/apps/api/preview/design-get-design-metadata/) method, which allows apps to get information about the design.
- `@canva/platform` updated to version `2.2.0`.
  - Added the `notification.addToast`: [Notification API](https://www.canva.dev/docs/apps/api/latest/platform-notification-add-toast/) which allows apps to display lightweight toast messages in the Canva editor.
- `examples`
  - Added `examples/notification` as a basic implementation of the new `@canva/platform` [`notification.addToast()`](https://www.canva.dev/docs/apps/api/latest/platform-notification-add-toast/) API.
  - Added `examples/design_metadata` as a basic implementation to demonstrate the new [`getDesignMetadata`](https://www.canva.dev/docs/apps/api/preview/design-get-design-metadata/) method.

### 🔧 Changed

- Upgraded `webpack-dev-server` to version `5.2.2` from `5.2.0` and adjusted the webpack configuration to work with the new version.
- `@canva/design` updated to version `2.6.0`.
  - `openDesign`: [Design Editing API](https://www.canva.dev/docs/apps/api/latest/design-open-design/) is out of preview and Generally Available!
    - `openDesign` function signature change:
      - Before: `openDesign({ type: 'current_page' }, (draft: { page, save }, helpers) => {})`.
      - After: `openDesign({ type: 'current_page' }, (session: { page, sync, helpers }) => {})`.
        - `save` is superseded by `sync`. Unlike `save`, `sync` can be called multiple times as needed.
    - `page`:
      - Renamed page type: `fixed` → `absolute`.
      - New page type: `unsupported`, which represents pages that are not `absolute` (previously `fixed`).
    - `helpers`:
      - Renamed `elementBuilder` to `elementStateBuilder`.
        - `cloneElement` was removed as part of the refactor.
    - Fills:
      - `media` and `color` are superseded by `mediaContainer` and `colorContainer`.
        - Read: `xxxContainer.ref`.
        - Write: `xxxContainer.set(...)`.
      - For shape path fills, `isMediaEditable` introduced to indicate editability.
- `examples`:
  - Updated `examples/authentication` to better align with the API spec.
  - Updated `examples/design_editing` to reflect the latest `@canva/design` changes.
