### PR TITLE
Use App UI Kit 4.10.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - `helpers`: New async helper methods `group` and `ungroup`. See the documentation on [PageHelpers](https://www.canva.dev/docs/apps/api/latest/design-types-page-helpers/) for more information.
 - `@canva/design@beta`
   - Added the [`getDesignMetadata`](https://www.canva.dev/docs/apps/api/preview/design-get-design-metadata/) method, which allows apps to get information about the design.
+  - Added a new content type to the [`EditContent`] method, enabling apps to edit image and video fill content within a page.
 - `@canva/platform` updated to version `2.2.0`.
   - Added the `notification.addToast`: [Notification API](https://www.canva.dev/docs/apps/api/latest/platform-notification-add-toast/) which allows apps to display lightweight toast messages in the Canva editor.
 - `examples`
@@ -17,6 +18,7 @@
 
 ### 🔧 Changed
 
+- Upgraded `@canva/app-ui-kit` to version `4.10.0`. Please see the [changelog](https://www.canva.dev/docs/apps/app-ui-kit/changelog/) for the list of changes.
 - Upgraded `webpack-dev-server` to version `5.2.2` from `5.2.0` and adjusted the webpack configuration to work with the new version.
 - `@canva/design` updated to version `2.6.0`.
   - `openDesign`: [Design Editing API](https://www.canva.dev/docs/apps/api/latest/design-open-design/) is out of preview and Generally Available!

--- a/examples/design_metadata/package.json
+++ b/examples/design_metadata/package.json
@@ -4,6 +4,6 @@
   "author": "Canva Pty Ltd.",
   "license": "Please refer to the LICENSE.md file in the root directory",
   "dependencies": {
-    "@canva/design": "^2.6.0-beta.1"
+    "@canva/design": "^2.6.2-beta.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "dependencies": {
         "@canva/app-i18n-kit": "^1.0.2",
-        "@canva/app-ui-kit": "^4.9.0",
+        "@canva/app-ui-kit": "^4.10.0",
         "@canva/asset": "^2.2.0",
         "@canva/design": "^2.6.0",
         "@canva/error": "^2.1.0",
@@ -161,14 +161,13 @@
     "examples/design_metadata": {
       "license": "Please refer to the LICENSE.md file in the root directory",
       "dependencies": {
-        "@canva/design": "^2.6.0-beta.1"
+        "@canva/design": "^2.6.2-beta.1"
       }
     },
     "examples/design_metadata/node_modules/@canva/design": {
-      "version": "2.6.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@canva/design/-/design-2.6.0-beta.1.tgz",
-      "integrity": "sha512-53X6tYLk1dSksNWMpr+Vd+AY5KKQJ6C4U0dVJTgnMaYHPubOagn7mbsWXYpt772tgpD/C3FStCNOZBlClVLxlw==",
-      "license": "SEE LICENSE IN LICENSE.md FILE",
+      "version": "2.6.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@canva/design/-/design-2.6.2-beta.1.tgz",
+      "integrity": "sha512-9fCAHi1A58RKaCPQcI0xCxuXFdvWWlTlFbllZ4lKnuT0gPC8vWMyvJ2jl+/3lywdXcc6Zn5fudGbO3mQmvhjzA==",
       "peerDependencies": {
         "@canva/error": "^2.0.0"
       }
@@ -338,7 +337,7 @@
       "extraneous": true,
       "license": "Please refer to the LICENSE.md file in the root directory",
       "dependencies": {
-        "@canva/design": "^2.6.0-beta.1",
+        "@canva/design": "^2.6.2-beta.1",
         "clsx": "2.1.1"
       }
     },
@@ -2198,17 +2197,15 @@
       }
     },
     "node_modules/@canva/app-ui-kit": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@canva/app-ui-kit/-/app-ui-kit-4.9.0.tgz",
-      "integrity": "sha512-qsenT6eSKE9c9vMcN98KnP++4bHhnrLZXGSxQYnObpIg0rQvL6/1wfQ+yWPKesjaCNXEMxcNEG14DZcz9oy/3Q==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@canva/app-ui-kit/-/app-ui-kit-4.10.0.tgz",
+      "integrity": "sha512-xYmabhMTSCkud6jBO18VDRBvInl++etSt/5z5UEBBev+OqhnVnLGyRLZsB+tls5hIk74bDNCJ25+HMu70gyksg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@floating-ui/react": "^0.26.16",
         "@seznam/compose-react-refs": "^1.0.4",
         "classnames": "^2.5.1",
         "intl-messageformat": "^10.5.4",
-        "intl-pluralrules": "^2.0.1",
-        "make-plural": "^7.3.0",
         "mobx": "6.13.5",
         "mobx-react-lite": "^4.1.0",
         "mobx-utils": "^6.1.0",
@@ -9246,12 +9243,6 @@
         "tslib": "2"
       }
     },
-    "node_modules/intl-pluralrules": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/intl-pluralrules/-/intl-pluralrules-2.0.1.tgz",
-      "integrity": "sha512-astxTLzIdXPeN0K9Rumi6LfMpm3rvNO0iJE+h/k8Kr/is+wPbRe4ikyDjlLr6VTh/mEfNv8RjN+gu3KwDiuhqg==",
-      "license": "ISC"
-    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -11307,12 +11298,6 @@
       "version": "1.3.6",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/make-plural": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.4.0.tgz",
-      "integrity": "sha512-4/gC9KVNTV6pvYg2gFeQYTW3mWaoJt7WZE5vrp1KnQDgW92JtYZnzmZT81oj/dUTqAIu0ufI2x3dkgu3bB1tYg==",
-      "license": "Unicode-DFS-2016"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@canva/app-i18n-kit": "^1.0.2",
-    "@canva/app-ui-kit": "^4.9.0",
+    "@canva/app-ui-kit": "^4.10.0",
     "@canva/asset": "^2.2.0",
     "@canva/design": "^2.6.0",
     "@canva/error": "^2.1.0",


### PR DESCRIPTION
Minor update to use @canva/app-ui-kit v4.10.0 and update the @canva/design beta used for the `design_metadata` example